### PR TITLE
Add `assignUsers` configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Many operating systems have an `open` command (though the name "open" is not ubi
 ### PR
 Running `harmony pr` with a branch checked out will reach out to GitHub to determine if there is an open PR for that branch. If there is a PR, Harmony will print a URI that can be used to view the PR. IF there is not a PR, Harmony will help you create one.
 
-If you need to create a PR still, you will be prompted for a branch to open the PR against (merge into, eventually), a title for the PR, and a description for the PR. If you have an `EDITOR` environment variable set, Harmony will use that editor to get the PR description from you. If you have a PR template at `.github/PULL_REQUEST_TEMPLATE.md`, Harmony will also preload that into your editor. If you do not have an `EDITOR` environment variable set, you will still be able to enter a description from the command line; PR templates are not supported for this input mode.
+If you need to create a PR still, you will be prompted for a branch to open the PR against (merge into, eventually), a title for the PR, and a description for the PR. If you have an `EDITOR` environment variable set, Harmony will use that editor to get the PR description from you. If you have a PR template at `.github/PULL_REQUEST_TEMPLATE.md`, Harmony will also preload that into your editor. If you do not have an `EDITOR` environment variable set, you will still be able to enter a description from the command line but PR templates are only supported when an `EDITOR` is specified.
 
 Many operating systems have an `open` command (though the name "open" is not ubiquitous); this means you can run something like `open $(harmony pr)` to open a web browser to an existing PR for the current branch.
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,12 @@ Running `harmony list <team>` will list the members of the given GitHub Team.
 Running `harmony graph <team>` will graph the relative review workload of each of the members of the given GitHub Team.
 
 ### Config
-Running `harmony config <property>` read the given configuration property. `harmony config <property> <value>` will set the configuration property.
+Running `harmony config <property>` will read the given configuration property. `harmony config <property> <value>` will set the configuration property.
 
 Not all configuration properties can be read/set with this command.
 #### Properties
 - `assignTeams` -- When picking a reviewer from a team, assign the team as a reviewer as well.
+- `assignUsers` -- When assigning a team as a reviewer, pick a user to review as well.
 - `commentOnAssign` -- When assigning a reviewer chosen by Harmony, comment on the pull request.
 - `defaultRemote` -- When pushing new branches, what remote destination should be used.
 - `githubPAT` -- If the `$GITHUB_PAT` environment variable is not set, this Personal Access Token is used to authenticate with GitHub.

--- a/harmony.ipkg
+++ b/harmony.ipkg
@@ -1,5 +1,5 @@
 package harmony
-version = 1.1.1
+version = 1.2.0
 authors = "Mathew Polzin"
 license = "MIT"
 -- brief =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattpolzin/harmony",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/src/AppVersion.idr
+++ b/src/AppVersion.idr
@@ -4,7 +4,7 @@ module AppVersion
 
 export
 appVersion : String
-appVersion = "1.1.1"
+appVersion = "1.2.0"
 
 export
 printVersion : HasIO io => io ()

--- a/src/AppVersion.idr
+++ b/src/AppVersion.idr
@@ -1,5 +1,7 @@
 module AppVersion
 
+%default total
+
 export
 appVersion : String
 appVersion = "1.1.1"

--- a/src/BashCompletion.idr
+++ b/src/BashCompletion.idr
@@ -65,8 +65,8 @@ opts : Config => String -> String -> List String
 -- should have already been called).
 
 -- then the config command
-opts @{_} "--" "config" = settableProps
-opts @{_} partialConfigProp "config" = filter (isPrefixOf partialConfigProp) settableProps
+opts @{_} "--" "config" = settablePropNames
+opts @{_} partialConfigProp "config" = filter (isPrefixOf partialConfigProp) settablePropNames
 
 -- then list, which only accepts a single team slug:
 opts @{config} "--" "list"   = config.teamSlugs

--- a/src/BashCompletion.idr
+++ b/src/BashCompletion.idr
@@ -4,8 +4,6 @@ import Data.Config
 import Data.List
 import Data.String
 
-import Debug.Trace
-
 %default total
 
 allRootCmds : List String

--- a/src/Config.idr
+++ b/src/Config.idr
@@ -207,7 +207,7 @@ createConfig envGithubPAT terminalColors editor = do
   putStr "Would you like harmony to comment when it assigns reviewers? [Y/n] "
   commentOnAssign <- yesUnlessNo . trim <$> getLine
 
-  putStr "Would you like harmony to assign teams in addition to individuals when it assigns reviewers? [Y/n] "
+  putStr "Would you like harmony to assign teams when it assigns reviewers? [Y/n] "
   assignTeams <- yesUnlessNo . trim <$> getLine
 
   putStr "Would you like harmony to assign individual users when it assigns reviewers? [Y/n] "
@@ -250,12 +250,10 @@ createConfig envGithubPAT terminalColors editor = do
     orIfEmpty (Just _) x  = x
 
     yesUnlessNo : String -> Bool
-    yesUnlessNo "n" = False
-    yesUnlessNo "N" = False
-    yesUnlessNo "no" = False
-    yesUnlessNo "NO" = False
-    yesUnlessNo "No" = False
-    yesUnlessNo _   = True
+    yesUnlessNo answer with (toLower answer)
+      _ | "n"   = False
+      _ | "no"  = False
+      _ | _     = True
 
     org : Maybe GitRemote -> Maybe String
     org = map (.org)

--- a/src/Data/Config.idr
+++ b/src/Data/Config.idr
@@ -7,6 +7,7 @@ import Data.String
 import Data.Vect
 import Language.JSON
 import Language.JSON.Accessors
+
 import public Data.DPair
 
 %default total

--- a/src/Data/Config.idr
+++ b/src/Data/Config.idr
@@ -2,10 +2,12 @@ module Data.Config
 
 import Data.Either
 import Data.List
+import Data.List.Elem
 import Data.String
 import Data.Vect
 import Language.JSON
 import Language.JSON.Accessors
+import public Data.DPair
 
 %default total
 
@@ -71,13 +73,75 @@ record Config where
 %name Config config
 
 public export
-settableProps : List String
+data SettableProp : (name : String) -> (help : String) -> Type where
+  AssignTeams     : SettableProp "assignTeams"
+                                 "[true/false] Determines whether or not to assign teams when assigning individual reviewers."
+  CommentOnAssign : SettableProp "commentOnAssign"
+                                 "[true/false] Determines whether to comment on PR indicating that Harmony chose a reviewer."
+  DefaultRemote   : SettableProp "defaultRemote"
+                                 "[string]     The name of the default Git remote to use (e.g. 'origin')."
+  GithubPAT       : SettableProp "githubPAT"
+                                 "[string]     The Personal Access Token Harmony should use to authenticate with GitHub. You can leave this unset if you want to set a PAT via the GITHUB_PAT environment variable."
+
+public export
+SomeSettableProp : Type
+SomeSettableProp = (n ** h ** SettableProp n h)
+
+public export
+propName : {n : _} -> SettableProp n h -> String
+propName x = n
+
+public export
+propHelp : {h : _} -> SettableProp n h -> String
+propHelp x = h
+
+export
+settablePropNamed : (name : String) -> Maybe (Exists (SettableProp name))
+settablePropNamed "assignTeams"     = Just $ Evidence _ AssignTeams
+settablePropNamed "commentOnAssign" = Just $ Evidence _ CommentOnAssign
+settablePropNamed "defaultRemote"   = Just $ Evidence _ DefaultRemote
+settablePropNamed "githubPAT"       = Just $ Evidence _ GithubPAT
+settablePropNamed _ = Nothing
+
+namespace SettablePropNamedProps
+  settablePropNamedOnto : {p : SettableProp n h} -> Config.settablePropNamed n === (Just $ Evidence h p)
+  settablePropNamedOnto {p = AssignTeams}     = Refl
+  settablePropNamedOnto {p = CommentOnAssign} = Refl
+  settablePropNamedOnto {p = DefaultRemote}   = Refl
+  settablePropNamedOnto {p = GithubPAT}       = Refl
+
+settableProps : List SomeSettableProp
 settableProps = [
-    "assignTeams"
-  , "commentOnAssign"
-  , "defaultRemote"
-  , "githubPAT"
+    (_ ** _ ** AssignTeams)
+  , (_ ** _ ** CommentOnAssign)
+  , (_ ** _ ** DefaultRemote)
+  , (_ ** _ ** GithubPAT)
   ]
+
+namespace SettablePropsProps
+  settablePropsCovering : {p : SettableProp n h} -> Elem (n ** h ** p) Config.settableProps
+  settablePropsCovering {p = AssignTeams}     = %search
+  settablePropsCovering {p = CommentOnAssign} = %search
+  settablePropsCovering {p = DefaultRemote}   = %search
+  settablePropsCovering {p = GithubPAT}       = %search
+
+propName' : SomeSettableProp -> String
+propName' (_ ** _ ** p) = propName p
+
+propHelp' : SomeSettableProp -> String
+propHelp' (_ ** _ ** p) = propHelp p
+
+export
+settablePropNames : List String
+settablePropNames = propName' <$> settableProps
+
+export
+settablePropNamesAndHelp : List (String, String)
+settablePropNamesAndHelp = (\p => (propName' p, propHelp' p)) <$> settableProps
+
+export
+longestSettablePropName : Nat
+longestSettablePropName = foldr max 0 $ (length . propName') <$> settableProps
 
 export
 (.filepath) : Config -> String

--- a/src/Data/Review.idr
+++ b/src/Data/Review.idr
@@ -2,9 +2,9 @@ module Data.Review
 
 import Data.Date
 import Data.Either
+import Data.Vect
 import Language.JSON
 import Language.JSON.Accessors
-import Data.Vect
 
 %default total
 

--- a/src/FFI/Concurrency.idr
+++ b/src/FFI/Concurrency.idr
@@ -1,10 +1,10 @@
 module FFI.Concurrency
 
-import FFI
-import Data.List1
-import Data.Vect
 import Data.Either
+import Data.List1
 import Data.Promise
+import Data.Vect
+import FFI
 import Language.JSON
 
 %default total

--- a/src/FFI/Git.idr
+++ b/src/FFI/Git.idr
@@ -112,6 +112,8 @@ prim__rootDir : Ptr GitRef
              -> (onFailure : String -> PrimIO ())
              -> PrimIO ()
 
+||| Get the absolute path of the Git repository's root directory
+||| (the location of the `.git` folder).
 export
 rootDir : Git => Promise String
 rootDir @{G ptr} = promiseIO $ prim__rootDir ptr

--- a/src/Help.idr
+++ b/src/Help.idr
@@ -2,6 +2,7 @@ module Help
 
 import Data.Config
 import Data.String
+
 import Text.PrettyPrint.Prettyprinter
 import Text.PrettyPrint.Prettyprinter.Render.Terminal
 

--- a/src/Help.idr
+++ b/src/Help.idr
@@ -21,7 +21,7 @@ harmony \{subcommand "<subcommand>"}
   \{subcommand "config"} {\{argument "<property>"}} [\{argument "<value>"}]
    - Get or set the value of a configuration property. Not all properties
      can be set and read via this subcommand.
-     \{argument "properties"}: \{join ", " $ option <$> settableProps}.
+     \{argument "properties"}: \{join ", " $ option <$> settablePropNames}.
   \{subcommand "sync"}
    - Synchronize local config with information from GitHub.
   \{subcommand "branch"}

--- a/src/Main.idr
+++ b/src/Main.idr
@@ -21,10 +21,11 @@ import PullRequest as PR
 import Reviewer
 import System
 import System.File
-import Text.PrettyPrint.Prettyprinter
-import Text.PrettyPrint.Prettyprinter.Render.Terminal
 import User
 import Util
+
+import Text.PrettyPrint.Prettyprinter
+import Text.PrettyPrint.Prettyprinter.Render.Terminal
 
 %default total
 

--- a/src/Main.idr
+++ b/src/Main.idr
@@ -227,6 +227,8 @@ handleConfiguredArgs : Config => Git =>
 handleConfiguredArgs _ ["config"] =
   reject $ "The config command expects one or two arguments. "
         ++ "Specify a property to read out or a property and a value to set it to."
+        ++ "\n\n"
+        ++ settablePropsWithHelp
 handleConfiguredArgs _ ["config", prop] =
   do value <- getConfig prop
      putStrLn value

--- a/src/Reviewer.idr
+++ b/src/Reviewer.idr
@@ -1,15 +1,16 @@
 module Reviewer
 
-import Data.Nat
-import Data.String
 import Data.List
 import Data.List.DeleteBy
 import Data.List1
+import Data.Nat
+import Data.String
 import System.Random.Node
-import Text.PrettyPrint.Prettyprinter
-import Text.PrettyPrint.Prettyprinter.Symbols
-import Text.PrettyPrint.Prettyprinter.Render.Terminal
 import Util
+
+import Text.PrettyPrint.Prettyprinter
+import Text.PrettyPrint.Prettyprinter.Render.Terminal
+import Text.PrettyPrint.Prettyprinter.Symbols
 
 %default total
 

--- a/src/System/File/Node.idr
+++ b/src/System/File/Node.idr
@@ -1,5 +1,7 @@
 module System.File.Node
 
+%default total
+
 -- TODO: Remove this once Idris2 gains a version newer than 0.5.1. This has been added to the base library.
 
 %foreign "node:lambda:(f) => require('fs').unlinkSync(f)"

--- a/src/System/Node.idr
+++ b/src/System/Node.idr
@@ -2,6 +2,8 @@ module System.Node
 
 -- TODO: Remove this once Idris2 gains a version newer than 0.5.1. This has been added to the base library.
 
+%default total
+
 %foreign "node:lambda:(cmd) => require('child_process').spawnSync(cmd, [], {shell: true, stdio: 'inherit'}).status"
 prim__system : String -> PrimIO Int
 

--- a/src/User.idr
+++ b/src/User.idr
@@ -8,12 +8,13 @@ import Data.PullRequest
 import Data.Review
 import Data.String
 import Data.User
-import FFI.GitHub
 import FFI.Git
+import FFI.GitHub
 import PullRequest
+import Util
+
 import Text.PrettyPrint.Prettyprinter
 import Text.PrettyPrint.Prettyprinter.Render.Terminal
-import Util
 
 %default total
 

--- a/src/Util.idr
+++ b/src/Util.idr
@@ -3,7 +3,10 @@ module Util
 import Data.Config
 import Data.Fuel
 import Data.List
+import Data.Promise
 import Data.String
+import FFI.Git
+
 import Text.PrettyPrint.Prettyprinter
 import Text.PrettyPrint.Prettyprinter.Render.Terminal
 
@@ -35,6 +38,12 @@ getManyLines = getMoreLines []
          case (acc, line) of
               ("" :: rest, "") => pure (reverse rest)
               _                => getMoreLines (line :: acc) fuel
+
+||| Get an absolute path for the given directory or file assuming the
+||| given path is relative to the root of the Git repository.
+export
+relativeToRoot : Git => String -> Promise String
+relativeToRoot path = rootDir <&> (++ "/\{path}")
 
 ||| If possible, extract a Jira ticket reference from the given string.
 |||


### PR DESCRIPTION
Harmony has always assigned users from teams because the biggest reason for Harmony existing is to supply a heuristic upon which such assignments can be made.

However, GitHub also supports two styles of automated review request: round robin and a balancing heuristic. The new config option that allows turning off Harmony's user assignment feature allows Harmony to be used with GitHub's automatic assignment because Harmony will provide a CLI for creating PRs and assigning teams after which GitHub will take over and assign individuals.

When this is desirable, Harmony definitely does _less_ but it still surfaces a reasonable CLI to PR creation and team assignment, good auto-completion, and its reflect command is still useful.