### PR TITLE
Check for TTY, adjust PR creation behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ version:
 	$(ised) "s/appVersion = \".*\"/appVersion = \"${v}\"/" ./src/AppVersion.idr
 	$(ised) "s/\"version\": \".*\"/\"version\": \"${v}\"/" ./package.json
 	@npm update
-	@$(nix) fmt
+	@find . -name '*.nix' | xargs $(nix) fmt
 
 package: build
 	bash ./version-check.sh

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ If you need to create a PR still, you will be prompted for a branch to open the 
 
 You can also specify any number of labels to apply by prefixing them with '#'. For example, `harmony pr #backport #bugfix` would create a PR and apply the `backport` and `bugfix` labels.
 
+If you are using harmony from a script or some other environment without TTY support, harmony will print a GitHub URL that can be used to create the PR. This mode of operation will ignore the `--draft` and `#label` options.
+
 Many operating systems have an `open` command (though the name "open" is not ubiquitous); this means you can run something like `open $(harmony pr)` to open a web browser to an existing PR for the current branch.
 
 #### Examples

--- a/default.nix
+++ b/default.nix
@@ -24,7 +24,7 @@ let
   nodeDependencies = buildNpmPackage {
     name = "harmony-npm-deps";
     src = ./.;
-    npmDepsHash = "sha256-GRnI5EBmGnkXIsY3SK9Ma0uVias03GvqpMqdZOqfqqQ=";
+    npmDepsHash = "sha256-WcGeSdi1pBj1kkujWXo/ExokMy8D/qtpPTKcfq/rqWQ=";
     dontNpmBuild = true;
     dontBuild = true;
 

--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ let
     };
   };
 
-  nodeDependencies  = buildNpmPackage {
+  nodeDependencies = buildNpmPackage {
     name = "harmony-npm-deps";
     src = ./.;
     npmDepsHash = "sha256-GRnI5EBmGnkXIsY3SK9Ma0uVias03GvqpMqdZOqfqqQ=";

--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
     "idris2PackDbSrc": {
       "flake": false,
       "locked": {
-        "lastModified": 1745445529,
-        "narHash": "sha256-XRcH3zZuslLpjXJUIrgmi3qFqLwOzxRsUByJNTl4XOI=",
+        "lastModified": 1745791006,
+        "narHash": "sha256-Tcsw/QWESm8uPwuG3Cg46VuGim98jo+jrtdwwUW+bBM=",
         "owner": "stefan-hoeck",
         "repo": "idris2-pack-db",
-        "rev": "c0b716a8c966e19a7ae6c4ca8413ef5a00ade4ad",
+        "rev": "5035e1b2adf2cda8171ca2622f6a0014769c27c3",
         "type": "github"
       },
       "original": {
@@ -1263,11 +1263,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1745377448,
+        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
         "type": "github"
       },
       "original": {
@@ -1285,11 +1285,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745458822,
-        "narHash": "sha256-cq5IMJy3Y/zGgsQDet+egjYPrTvQHtLuOoRG88dEH6M=",
+        "lastModified": 1745804406,
+        "narHash": "sha256-DB8FMMRWEdR0WhsWmCF4NKYxKwYMAG0mFBYWaU9KPs8=",
         "owner": "mattpolzin",
         "repo": "nix-idris2-packages",
-        "rev": "b06ec1fe1c2067a3e403f22e3e5777e32202d2c8",
+        "rev": "cef35eff606a8c30b39d324d4a02ea5af43f06f3",
         "type": "github"
       },
       "original": {

--- a/harmony.ipkg
+++ b/harmony.ipkg
@@ -1,5 +1,5 @@
 package harmony
-version = 5.1.0
+version = 5.2.0
 authors = "Mathew Polzin"
 license = "MIT"
 brief = "Harmony GitHub collaboration tool"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mattpolzin/harmony",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mattpolzin/harmony",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "octokit": "^3.1",
@@ -190,15 +190,15 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.3.1",
-        "@octokit/request-error": "^5.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
         "@octokit/types": "^13.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
-      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-graphql": {
@@ -404,12 +404,12 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
-      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^23.0.1"
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@octokit/webhooks": {
@@ -443,9 +443,9 @@
       "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.147",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.147.tgz",
-      "integrity": "sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==",
+      "version": "8.10.149",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.149.tgz",
+      "integrity": "sha512-NXSZIhfJjnXqJgtS7IwutqIF/SOy1Wz5Px4gUY1RWITp3AYTyuJS4xaXr/bIJY1v15XMzrJ5soGnPM+7uigZjA==",
       "license": "MIT"
     },
     "node_modules/@types/btoa-lite": {
@@ -471,12 +471,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
+      "version": "22.15.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
+      "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/universal-github-app-jwt": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattpolzin/harmony",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/src/AppVersion.idr
+++ b/src/AppVersion.idr
@@ -4,7 +4,7 @@ module AppVersion
 
 export
 appVersion : String
-appVersion = "5.1.0"
+appVersion = "5.2.0"
 
 export
 printVersion : HasIO io => io ()


### PR DESCRIPTION
If no existing PR can be found and the current shell is not TTY then instead of the usual interactive process for creating a new PR just print out a URI that can be used to create a PR via GitHub's web interface.

Closes #149