### PR TITLE
fix quick shell comp

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
     "idris2PackDbSrc": {
       "flake": false,
       "locked": {
-        "lastModified": 1768775631,
-        "narHash": "sha256-nyheq99eE3EU21js46fhf3V5G27iVbpQ6TAoEvmoWOQ=",
+        "lastModified": 1769121374,
+        "narHash": "sha256-xitgMKA7CYY+k1oLKDYdMmsAa2zzGiy3ifyzinNqoHo=",
         "owner": "stefan-hoeck",
         "repo": "idris2-pack-db",
-        "rev": "759e1bf54ff02531bb88f7abe6d985852d37b1cf",
+        "rev": "038a8862d3751d26162edea4d5c964da394f70bd",
         "type": "github"
       },
       "original": {
@@ -368,11 +368,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768783163,
-        "narHash": "sha256-tLj4KcRDLakrlpvboTJDKsrp6z2XLwyQ4Zmo+w8KsY4=",
+        "lastModified": 1769092226,
+        "narHash": "sha256-6h5sROT/3CTHvzPy9koKBmoCa2eJKh4fzQK8eYFEgl8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bde09022887110deb780067364a0818e89258968",
+        "rev": "b579d443b37c9c5373044201ea77604e37e748c8",
         "type": "github"
       },
       "original": {
@@ -384,11 +384,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1768661221,
-        "narHash": "sha256-MJwOjrIISfOpdI9x4C+5WFQXvHtOuj5mqLZ4TMEtk1M=",
+        "lastModified": 1768875095,
+        "narHash": "sha256-dYP3DjiL7oIiiq3H65tGIXXIT1Waiadmv93JS0sS+8A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3327b113f2ef698d380df83fbccefad7e83d7769",
+        "rev": "ed142ab1b3a092c4d149245d0c4126a5d7ea00b0",
         "type": "github"
       },
       "original": {
@@ -406,11 +406,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1768787057,
-        "narHash": "sha256-b5nXkhiUNFUkx+8OPK7diCQHS+tTDuqSQMl+DX8qEfQ=",
+        "lastModified": 1769132518,
+        "narHash": "sha256-LdUCK2B4ubQ7kGY0eFSc76L8B/besaXHMvKPe+uYPQM=",
         "owner": "mattpolzin",
         "repo": "nix-idris2-packages",
-        "rev": "1d0b952b20b33c604b7332ac3de31fcaa8eeef58",
+        "rev": "51f9c76ac6247d1e24ff9be8d4a8a8ae69ac17e4",
         "type": "github"
       },
       "original": {

--- a/src/Main.idr
+++ b/src/Main.idr
@@ -75,7 +75,7 @@ shellCompletion envPAT completionStyle subcommand curWord prevWord =
 
     gitCompletions : Config => Lazy Octokit -> Promise' (List String)
     gitCompletions gh =
-      gitOpts gh completionStyle subcommand curWord prevWord
+      githubOpts gh completionStyle subcommand curWord prevWord
 
     completions : Promise' (List String)
     completions = do

--- a/src/ShellCompletion/Common.idr
+++ b/src/ShellCompletion/Common.idr
@@ -279,19 +279,19 @@ namespace TestHashifyIfPrefix
     in  rewrite postulateIntegerShown in Refl
 
 export
-gitOpts : Config =>
-          Lazy Octokit
-       -> (s : CompletionStyle)
-       -> (subcommand : String)
-       -> (curWord : String)
-       -> (prevWord : String)
-       -> Promise' (List String)
-gitOpts @{config} gh _ "quick" partialArg _ = do
+githubOpts : Config =>
+             Lazy Octokit
+          -> (s : CompletionStyle)
+          -> (subcommand : String)
+          -> (curWord : String)
+          -> (prevWord : String)
+          -> Promise' (List String)
+githubOpts @{config} gh _ "quick" partialArg _ = do
   issues <- listIssues @{gh} config.org config.repo
   let partialArg' = unhashify partialArg
   let str = stringify . completionResult
   pure $ 
     mapMaybe (\i => str . (, i.title) <$> hashifyIfPrefix partialArg' i.number)
              issues
-gitOpts _ _ _ _ _ = pure []
+githubOpts _ _ _ _ _ = pure []
 

--- a/src/ShellCompletion/Common.idr
+++ b/src/ShellCompletion/Common.idr
@@ -260,10 +260,23 @@ configuredOpts _ _ _ _ = []
 
 hashifyIfPrefix : (substr : String) -> (issueNumber : Integer) -> Maybe String
 hashifyIfPrefix substr num =
-  let hashified = hashify $ show num
-  in  if substr `isPrefixOf` hashified
-         then Just hashified
+  let numStr := show num
+  in  if substr `isPrefixOf` numStr
+         then Just . hashify $ numStr
          else Nothing
+
+namespace TestHashifyIfPrefix
+  testUnhashedMatch : hashifyIfPrefix "12" 1234 === Just "#1234"
+  testUnhashedMatch =
+    let postulateIntegerShown : show 1234 === "1234"
+        postulateIntegerShown = believe_me (Refl {x="1234"})
+    in rewrite postulateIntegerShown in Refl
+
+  testUnhashedNonMatch : hashifyIfPrefix "34" 1234 === Nothing
+  testUnhashedNonMatch =
+    let postulateIntegerShown : show 1234 === "1234"
+        postulateIntegerShown = believe_me (Refl {x="1234"})
+    in  rewrite postulateIntegerShown in Refl
 
 export
 gitOpts : Config =>
@@ -275,9 +288,10 @@ gitOpts : Config =>
        -> Promise' (List String)
 gitOpts @{config} gh _ "quick" partialArg _ = do
   issues <- listIssues @{gh} config.org config.repo
+  let partialArg' = unhashify partialArg
   let str = stringify . completionResult
   pure $ 
-    mapMaybe (\i => str . (, i.title) <$> hashifyIfPrefix partialArg i.number)
+    mapMaybe (\i => str . (, i.title) <$> hashifyIfPrefix partialArg' i.number)
              issues
 gitOpts _ _ _ _ _ = pure []
 

--- a/src/ShellCompletion/Util.idr
+++ b/src/ShellCompletion/Util.idr
@@ -24,7 +24,7 @@ public export
 unslugify : String -> String
 unslugify = pack . replaceOn '◌' ' ' . unpack
 
-export
+public export
 hashify : String -> String
 hashify = strCons '#'
 
@@ -56,7 +56,7 @@ namespace TestUnhashify
   test5 : unhashify "\\#hello" = "hello"
   test5 = Refl
 
-export
+public export
 isPrefixOf : (s : CompletionStyle) => String -> CompletionResult -> Bool
 isPrefixOf str = isPrefixOf str . name
 


### PR DESCRIPTION
<!--
## GitHub Issue
fix quick shell comp
--
-->

Closes #243

Fix shell completion of issue numbers for quick command. It is broken once the hash got escaped which it needed to almost immediately.

