### PR TITLE
Crash after marking PR ready

### DIFF
--- a/src/Commands.idr
+++ b/src/Commands.idr
@@ -531,11 +531,16 @@ namespace TestTitleArg
   testNothingForOnlyBugfix = Refl
 
 titleOrNumberArg : List QuickArg -> IssueIdent
-titleOrNumberArg [IssueNumOrTitle str] =
-  if isHashPrefix str
-     then IssueNumber $ drop 1 str
-     else IssueTitle str
-titleOrNumberArg args = maybe NoInfo IssueTitle $ titleArg args
+titleOrNumberArg args =
+  go $ filter (\case ABugfix => False; _ => True) args
+
+  where
+    go : List QuickArg -> IssueIdent
+    go [IssueNumOrTitle str] =
+      if isHashPrefix str
+         then IssueNumber $ drop 1 str
+         else IssueTitle str
+    go args = maybe NoInfo IssueTitle $ titleArg args
 
 namespace TestTitleOrNumberArg
   singleHashArgumentIsIssueNumber : titleOrNumberArg [IssueNumOrTitle "#1234"] === IssueNumber "1234"
@@ -546,6 +551,9 @@ namespace TestTitleOrNumberArg
 
   multipleArgumentsIsTitle : titleOrNumberArg [IssueNumOrTitle "#1234", IssueNumOrTitle "hi"] === IssueTitle "#1234 hi"
   multipleArgumentsIsTitle = Refl
+
+  singleHashArgPlusFlagIsNumber : titleOrNumberArg [ABugfix, IssueNumOrTitle "#1234"] === IssueNumber "1234"
+  singleHashArgPlusFlagIsNumber = Refl
 
 issueCategory : List QuickArg -> IssueCategory
 issueCategory = maybe Feature (const Bugfix) . find (\case ABugfix => True; _ => False)

--- a/src/Commands.idr
+++ b/src/Commands.idr
@@ -555,6 +555,9 @@ namespace TestTitleOrNumberArg
   singleHashArgPlusFlagIsNumber : titleOrNumberArg [ABugfix, IssueNumOrTitle "#1234"] === IssueNumber "1234"
   singleHashArgPlusFlagIsNumber = Refl
 
+  singleHashArgPlusFlagIsNumber' : titleOrNumberArg [IssueNumOrTitle "#1234", ABugfix] === IssueNumber "1234"
+  singleHashArgPlusFlagIsNumber' = Refl
+
 issueCategory : List QuickArg -> IssueCategory
 issueCategory = maybe Feature (const Bugfix) . find (\case ABugfix => True; _ => False)
 

--- a/src/Commands/Quick.idr
+++ b/src/Commands/Quick.idr
@@ -28,6 +28,13 @@ namespace TestDasherize
   replacesSpacesWithDashes : dasherize "a b c" === "a-b-c"
   replacesSpacesWithDashes = Refl
 
+branchNameSuggestion : String -> String
+branchNameSuggestion = toLower . dasherize
+
+namespace TestBranchNameSuggestion
+  testUppercaseAndSpace : branchNameSuggestion "A branch-Name-candidate" === "a-branch-name-candidate"
+  testUppercaseAndSpace = Refl
+
 createNewIssue : Config =>
                  Octokit =>
                  (issueTitle : Maybe String)
@@ -72,7 +79,7 @@ quickStartNewWork @{config} issueCategory issueIdent = do
                 IssueNumber issueNum   => getIssue config.org config.repo issueNum
 
   let branchTemplate = "\{branchPrefix}/\{show issue.number}/"
-  let defaultBranchSlug = dasherize issue.title
+  let defaultBranchSlug = branchNameSuggestion issue.title
   let defaultBranchName = branchTemplate ++ defaultBranchSlug
   putStrLn "What would you like the branch to be named? \{enterForDefaultStr defaultBranchName}"
   putStr branchTemplate

--- a/support/js/okit.js
+++ b/support/js/okit.js
@@ -241,7 +241,7 @@ const okit_mark_pr_ready = (octokit, opaque_pr_graphql_id, onSuccess, onFailure)
       }`,
       opaque_pr_graphql_id
     }),
-    r => onSuccess(JSON.stringify(digGraphQlPr(r.convertPullRequestToReady.pullRequest))),
+    r => onSuccess(JSON.stringify(digGraphQlPr(r.markPullRequestReadyForReview.pullRequest))),
     onFailure
   )
 


### PR DESCRIPTION
<!--
## GitHub Issue
Crash after marking PR ready
--
harmony succeeds in marking the PR ready but then crashes:
```
$ harmony pr --ready
https://github.com/opallabs/cabochon/pull/16037

Are you sure you want to mark the existing PR for the current branch ready for review? [y/N] y
/nix/store/841qi8n6429knx2149kkcr8z7h17d2c4-harmony-6.2.0/bin/.harmony-wrapped:498
    r => onSuccess(JSON.stringify(digGraphQlPr(r.convertPullRequestToReady.pullRequest))),
                                                                           ^

TypeError: Cannot read properties of undefined (reading 'pullRequest')
    at /nix/store/841qi8n6429knx2149kkcr8z7h17d2c4-harmony-6.2.0/bin/.harmony-wrapped:498:76
    at /nix/store/841qi8n6429knx2149kkcr8z7h17d2c4-harmony-6.2.0/bin/.harmony-wrapped:266:21

Node.js v22.21.1
```
-->

Fixes #241
