### PR TITLE
make quick only issues

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
         in
         {
           default = pkgs.mkShell {
-            inputsFrom = [ self.packages.${system}.harmony ];
+            inputsFrom = [ self.packages.${system}.harmony.withSource ];
             packages = [
               idris2
               idris2Lsp

--- a/src/Config.idr
+++ b/src/Config.idr
@@ -8,6 +8,7 @@ import Data.List1
 import Data.Promise
 import Data.String
 import Data.Theme
+import Data.User
 import Decidable.Equality
 import FFI.GitHub
 import JSON.Parser
@@ -38,11 +39,13 @@ syncConfig @{config} echo =
  do teamSlugs  <- nonOrgFallback [] $ listTeams config.org
     orgMembers <- nonOrgFallback [] $ listOrgMembers config.org
     labelNames <- listRepoLabels config.org config.repo
+    githubUser <- login <$> getSelf
     updatedAt  <- cast {to=Data.Config.Timestamp} <$> time
     let config' = { updatedAt  := updatedAt
                   , teamSlugs  := teamSlugs
                   , repoLabels := labelNames
                   , orgMembers := orgMembers
+                  , githubUser := Just githubUser
                   } config
     ignore $ writeConfig config'
     when echo $
@@ -263,6 +266,7 @@ createConfig envGithubPAT terminalColors terminalColumns editor = do
   do teamSlugs  <- nonOrgFallback [] $ listTeams org
      orgMembers <- nonOrgFallback [] $ listOrgMembers org
      repoLabels <- listRepoLabels org repo
+     githubUser <- login <$> getSelf
      let config = MkConfig {
          updatedAt
        , org
@@ -278,6 +282,7 @@ createConfig envGithubPAT terminalColors terminalColumns editor = do
        , orgMembers
        , ignoredPRs = []
        , githubPAT = hide <$> configPAT
+       , githubUser = Just githubUser
        , theme
        , ephemeral
        }

--- a/src/Data/Config.idr
+++ b/src/Data/Config.idr
@@ -146,6 +146,13 @@ record Config where
   ||| $GITHUB_PAT or $GH_TOKEN environment variable set. One of either the
   ||| environment variable or this config property must be set.
   githubPAT     : Maybe (Hidden String)
+  ||| Generally not used for harmony actions which can rely on the concept of a
+  ||| current (authenticated) user for any given GitHub request, but if shell
+  ||| completion or some other action is only indirectly related to a GitHub
+  ||| user then it may use this cached information.
+  |||
+  ||| This is the user's login or "slug"
+  githubUser    : Maybe String
   ||| Should Harmony print with colors fit for a dark terminal or a light
   ||| terminal?
   theme         : Theme
@@ -318,6 +325,7 @@ Show Config where
     , "      orgMembers: \{show config.orgMembers}"
     , "      ignoredPRs: \{show config.ignoredPRs}"
     , "       githubPAT: \{personalAccessToken}"
+    , "      githubUser: \{show config.githubUser}"
     ]
       where
         personalAccessToken : String
@@ -331,7 +339,7 @@ export
 json : Config -> JSON
 json (MkConfig updatedAt org repo defaultRemote mainBranch
                requestTeams requestUsers commentOnRequest branchParsing teamSlugs
-               repoLabels orgMembers ignoredPRs githubPAT theme _) =
+               repoLabels orgMembers ignoredPRs githubPAT githubUser theme _) =
   JObject [
       ("requestTeams"    , JBool requestTeams)
     , ("requestUsers"    , JBool requestUsers)
@@ -347,6 +355,7 @@ json (MkConfig updatedAt org repo defaultRemote mainBranch
     , ("repoLabels"      , JArray $ JString <$> sort repoLabels)
     , ("ignoredPRs"      , JArray $ JInteger . cast <$> sort ignoredPRs)
     , ("githubPAT"       , maybe JNull (JString . expose) githubPAT)
+    , ("githubUser"      , maybe JNull JString githubUser)
     , ("updatedAt"       , JInteger $ cast updatedAt)
     ]
 
@@ -389,6 +398,7 @@ parseConfig ephemeral = (mapFst (const "Failed to parse JSON") . parseJSON Virtu
                                               , "theme"
                                               ] config
                                           let maybeGithubPAT = lookup "githubPAT" config
+                                          let maybeGithubUser = lookup "githubUser" config
                                           let maybeBranchParsing = lookup "branchParsing" config
                                           ua <- cast <$> integer updatedAt
                                           o  <- string org
@@ -406,6 +416,9 @@ parseConfig ephemeral = (mapFst (const "Failed to parse JSON") . parseJSON Virtu
                                           om <- array string orgMembers
                                           ip <- array integer ignoredPRs
                                           gp <- maybe (Right Nothing) (optional string) maybeGithubPAT
+                                          gu <- maybe (Right Nothing) (optional string) maybeGithubUser
+                                          -- TODO 7.0.0: Make githubUser required part of config file (default to Nothing)
+                                          --             githubUser lookup can be moved to the required lookupAll above.
                                           th <- (stringy "dark or light" parseString) theme
                                           pure $ MkConfig {
                                               updatedAt         = ua
@@ -422,6 +435,7 @@ parseConfig ephemeral = (mapFst (const "Failed to parse JSON") . parseJSON Virtu
                                             , orgMembers        = om
                                             , ignoredPRs        = ip
                                             , githubPAT         = (map Hide) gp
+                                            , githubUser        = gu
                                             , theme             = th
                                             , ephemeral         = ephemeral
                                             }
@@ -463,6 +477,7 @@ simpleDefaults =
       , orgMembers        = []
       , ignoredPRs        = []
       , githubPAT         = Nothing
+      , githubUser        = Nothing
       , theme             = Dark
       , ephemeral         = MkEphem "path/to/repo" False 200 Nothing
       }

--- a/src/Data/Issue.idr
+++ b/src/Data/Issue.idr
@@ -25,12 +25,15 @@ record Issue where
   author    : String
   ||| The `login` of the assignee of the issue.
   assignee  : Maybe String
+  ||| The number of PRs linked to the issue. This is not returned for all
+  ||| queries; if not available then it is `Nothing`.
+  linkedPRCount : Maybe Nat
 
 %name Issue issue, issue1, issue2
 
 export
 Show Issue where
-  show (MkIssue number title _ _ author _) = 
+  show (MkIssue number title _ _ author _ _) = 
     "[\{show number}] \{authorString} - \{title}"
     where
       authorString : String
@@ -42,8 +45,8 @@ isAuthor login = (== login) . author
 
 export
 isAssignee : String -> Issue -> Bool
-isAssignee login (MkIssue _ _ _ _ _ Nothing) = False
-isAssignee login (MkIssue _ _ _ _ _ (Just assignee)) = login == assignee
+isAssignee login (MkIssue _ _ _ _ _ Nothing _) = False
+isAssignee login (MkIssue _ _ _ _ _ (Just assignee) _) = login == assignee
 
 parseDateTime : String -> Either String Date
 parseDateTime = maybeToEither "Failed to parse Date" . parseDateTimeString
@@ -52,13 +55,14 @@ export
 parseIssue : JSON -> Either String Issue
 parseIssue json =
  do issue <- object json
-    [issueNumber, issueTitle, issueBody, authorLogin, createdAtStr, assigneeLogin] <- lookupAll ["issue_number", "title", "body", "author", "created_at", "assignee"] issue
+    [issueNumber, issueTitle, issueBody, authorLogin, createdAtStr, assigneeLogin, prCount] <- lookupAll ["issue_number", "title", "body", "author", "created_at", "assignee", "linked_pr_count"] issue
     number      <- integer issueNumber
     title       <- string issueTitle
     body        <- maybe "" id <$> optional string issueBody
     author      <- string authorLogin
     createdAt   <- parseDateTime =<< string createdAtStr
     assignee    <- optional string assigneeLogin
+    linkedPRCount <- optional nat prCount 
     pure $ MkIssue {
         number
       , title
@@ -66,6 +70,7 @@ parseIssue json =
       , createdAt
       , author
       , assignee
+      , linkedPRCount
       }
 
 ||| Parse a single user from a JSON String

--- a/src/Data/Issue.idr
+++ b/src/Data/Issue.idr
@@ -55,14 +55,16 @@ export
 parseIssue : JSON -> Either String Issue
 parseIssue json =
  do issue <- object json
-    [issueNumber, issueTitle, issueBody, authorLogin, createdAtStr, assigneeLogin, prCount] <- lookupAll ["issue_number", "title", "body", "author", "created_at", "assignee", "linked_pr_count"] issue
+    [issueNumber, issueTitle, issueBody, authorLogin, createdAtStr, assigneeLogin] <- lookupAll ["issue_number", "title", "body", "author", "created_at", "assignee"] issue
     number      <- integer issueNumber
     title       <- string issueTitle
     body        <- maybe "" id <$> optional string issueBody
     author      <- string authorLogin
     createdAt   <- parseDateTime =<< string createdAtStr
     assignee    <- optional string assigneeLogin
-    linkedPRCount <- optional nat prCount 
+    linkedPRCount <- maybe (Right Nothing) 
+                           (optional nat)
+                           (lookup "linked_pr_count" issue)
     pure $ MkIssue {
         number
       , title

--- a/src/FFI/GitHub.idr
+++ b/src/FFI/GitHub.idr
@@ -206,7 +206,7 @@ createPR @{Kit ptr} {markAsDraft} owner repo head base title description =
   parsePrimResult parsePullRequestString $
     prim__createPR ptr owner repo head base title description markAsDraft
 
-%foreign okit_ffi "list_open_issues"
+%foreign okit_ffi "list_open_issues_graphql"
 prim__listIssues : Ptr OctokitRef 
                -> (owner : String) 
                -> (repo : String) 

--- a/src/Language/JSON/Accessors.idr
+++ b/src/Language/JSON/Accessors.idr
@@ -5,6 +5,7 @@ import Data.List
 import Data.Vect
 import JSON.Parser
 import JSON.Encoder
+import Data.String
 
 %default total
 
@@ -20,6 +21,10 @@ bool = access "bool" getBoolean
 export
 integer : JSON -> Either String Integer
 integer = access "integer" getInteger
+
+export
+nat : JSON -> Either String Nat
+nat = access "natural number" (map cast . getInteger)
 
 export
 string : JSON -> Either String String

--- a/src/ShellCompletion/Common.idr
+++ b/src/ShellCompletion/Common.idr
@@ -278,8 +278,8 @@ namespace TestHashifyIfPrefix
         postulateIntegerShown = believe_me (Refl {x="1234"})
     in  rewrite postulateIntegerShown in Refl
 
-describe : Issue -> String
-describe issue = "\{openPrs}\{issue.title}"
+describe : (githubUser : Maybe String) -> Issue -> String
+describe user issue = "\{assigned user}\{openPrs}\{issue.title}"
   where
     openPrs : String
     openPrs = case issue.linkedPRCount of
@@ -287,6 +287,54 @@ describe issue = "\{openPrs}\{issue.title}"
                    Just 1  => "{1 PR} "
                    Just n  => "{\{show n} PRs} "
                    Nothing => ""
+
+    assigned : Maybe String -> String
+    assigned Nothing           = ""
+    assigned (Just githubUser) =
+      case issue.assignee of
+           Nothing => ""
+           Just assignee =>
+             if assignee == githubUser
+                then "{yours} "
+                else "{taken} "
+
+||| Put issues assigned to the given user at the top and issues assigned to
+||| other users at the bottom with everything else between.
+compareAssignees : (githubUser : Maybe String) -> (assignee1 : Maybe String) -> (assignee2 : Maybe String) -> Ordering
+compareAssignees Nothing _ _ = EQ
+compareAssignees _ Nothing Nothing = EQ
+compareAssignees (Just u) Nothing (Just a2) =
+  if u == a2 then GT else LT
+compareAssignees (Just u) (Just a1) Nothing =
+  if u == a1 then LT else GT
+compareAssignees (Just u) (Just a1) (Just a2) =
+  if a1 == a2
+     then EQ
+     else if u == a2
+             then GT
+             else if u == a1
+                     then LT
+                     else EQ
+
+namespace TestCompareAssignees
+  noKnownGithubUser : (assignee1 : Maybe String) -> (assignee2 : Maybe String) -> compareAssignees Nothing assignee1 assignee2 === EQ
+  noKnownGithubUser _ _ = Refl
+
+  unassignedsAreEq : (githubUser : String) -> compareAssignees (Just githubUser) Nothing Nothing === EQ
+  unassignedsAreEq _ = Refl
+
+compareIssues : (githubUser : Maybe String) -> Issue -> Issue -> Ordering
+compareIssues u (MkIssue _ _ _ _ _ assignee1 (Just prCount1)) (MkIssue _ _ _ _ _ assignee2 (Just prCount2)) =
+  case compare prCount1 prCount2 of
+       LT => LT
+       GT => GT
+       EQ => compareAssignees u assignee1 assignee2
+compareIssues u (MkIssue _ _ _ _ _ assignee1 Nothing) (MkIssue _ _ _ _ _ assignee2 (Just _)) =
+  LT
+compareIssues u (MkIssue _ _ _ _ _ assignee1 (Just _)) (MkIssue _ _ _ _ _ assignee2 Nothing) =
+  GT
+compareIssues u (MkIssue _ _ _ _ _ assignee1 Nothing) (MkIssue _ _ _ _ _ assignee2 Nothing) =
+  compareAssignees u assignee1 assignee2
 
 export
 githubOpts : Config =>
@@ -300,9 +348,11 @@ githubOpts @{config} gh _ "quick" partialArg _ = do
   issues <- listIssues @{gh} config.org config.repo
   let partialArg' = unhashify partialArg
   let str = stringify . completionResult
+  let sorter = (compareIssues config.githubUser) `on` id . snd
+  let describer = describe config.githubUser
   let issues' =
     mapMaybe (\i => (, i) <$> hashifyIfPrefix partialArg' i.number)
              issues
-  pure (str . mapSnd describe <$> sortBy (compare `on` linkedPRCount . snd) issues')
+  pure (str . mapSnd describer <$> sortBy sorter issues')
 githubOpts _ _ _ _ _ = pure []
 

--- a/src/ShellCompletion/Common.idr
+++ b/src/ShellCompletion/Common.idr
@@ -348,7 +348,7 @@ githubOpts @{config} gh _ "quick" partialArg _ = do
   issues <- listIssues @{gh} config.org config.repo
   let partialArg' = unhashify partialArg
   let str = stringify . completionResult
-  let sorter = (compareIssues config.githubUser) `on` id . snd
+  let sorter = (compareIssues config.githubUser) `on` snd
   let describer = describe config.githubUser
   let issues' =
     mapMaybe (\i => (, i) <$> hashifyIfPrefix partialArg' i.number)

--- a/src/ShellCompletion/Common.idr
+++ b/src/ShellCompletion/Common.idr
@@ -278,6 +278,16 @@ namespace TestHashifyIfPrefix
         postulateIntegerShown = believe_me (Refl {x="1234"})
     in  rewrite postulateIntegerShown in Refl
 
+describe : Issue -> String
+describe issue = "\{openPrs}\{issue.title}"
+  where
+    openPrs : String
+    openPrs = case issue.linkedPRCount of
+                   Just 0  => ""
+                   Just 1  => "{1 PR} "
+                   Just n  => "{\{show n} PRs} "
+                   Nothing => ""
+
 export
 githubOpts : Config =>
              Lazy Octokit
@@ -290,8 +300,9 @@ githubOpts @{config} gh _ "quick" partialArg _ = do
   issues <- listIssues @{gh} config.org config.repo
   let partialArg' = unhashify partialArg
   let str = stringify . completionResult
-  pure $ 
-    mapMaybe (\i => str . (, i.title) <$> hashifyIfPrefix partialArg' i.number)
+  let issues' =
+    mapMaybe (\i => (, i) <$> hashifyIfPrefix partialArg' i.number)
              issues
+  pure (str . mapSnd describe <$> sortBy (compare `on` linkedPRCount . snd) issues')
 githubOpts _ _ _ _ _ = pure []
 

--- a/support/js/okit.js
+++ b/support/js/okit.js
@@ -279,7 +279,8 @@ const digIssue = issue => {
       created_at: issue.created_at,
       title: issue.title,
       body: issue.body,
-      assignee: issue.assignee ? issue.assignee.login : null
+      assignee: issue.assignee ? issue.assignee.login : null,
+      linked_branch_count: null
     }
   }
 const digIssues = issueJson =>
@@ -309,6 +310,54 @@ const okit_list_open_issues = (octokit, owner, repo, onSuccess, onFailure) =>
   idris__okit_unpromisify(
     octokit.rest.issues.listForRepo({ owner, repo, state: 'open', sort: 'updated', direction: 'desc' }),
     r => onSuccess(JSON.stringify(digIssues(r.data))),
+    onFailure
+  )
+
+// Get GraphQL Issue Data
+const digGraphQlIssue = issue => {
+    return {
+      graphql_id: issue.id,
+      issue_number: issue.number,
+      author: issue.author.login,
+//      state: issue.state.toLowerCase(),
+      created_at: issue.createdAt,
+      title: issue.title,
+      body: issue.body,
+      assignee: issue.assignedActors.nodes.map(a => a.login).first || null,
+      linked_pr_count: issue.closedByPullRequestsReferences.nodes.length
+    }
+  }
+const digGraphQlIssues = issueJson =>
+  issueJson.map(digGraphQlIssue)
+
+const graphql_issue_selections = `
+            id
+            number
+            author { ... on Actor { login } }
+            state
+            createdAt
+            title
+            body
+            assignedActors(first: 10) { nodes { ... on Actor { login } } }
+            closedByPullRequestsReferences(first: 10) { nodes { ... on PullRequest { number } } }
+`
+
+const okit_list_open_issues_graphql = (octokit, owner, repo, onSuccess, onFailure) =>
+  idris__okit_unpromisify(
+    octokit.graphql({
+      query: `query listIssues($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          issues(states: [OPEN], orderBy: {field: UPDATED_AT, direction: DESC}, first: 30) {
+            nodes { ... on Issue {
+              ${graphql_issue_selections}
+            }}
+          }
+        }
+      }`,
+      owner,
+      repo
+    }),
+    r => onSuccess(JSON.stringify(digGraphQlIssues(r.repository.issues.nodes))),
     onFailure
   )
 

--- a/support/js/okit.js
+++ b/support/js/okit.js
@@ -323,7 +323,7 @@ const digGraphQlIssue = issue => {
       created_at: issue.createdAt,
       title: issue.title,
       body: issue.body,
-      assignee: issue.assignedActors.nodes.map(a => a.login).first || null,
+      assignee: issue.assignedActors.nodes.map(a => a.login).at(0) || null,
       linked_pr_count: issue.closedByPullRequestsReferences.nodes.length
     }
   }

--- a/support/js/okit.js
+++ b/support/js/okit.js
@@ -280,7 +280,7 @@ const digIssue = issue => {
       title: issue.title,
       body: issue.body,
       assignee: issue.assignee ? issue.assignee.login : null,
-      linked_branch_count: null
+      linked_pr_count: null
     }
   }
 const digIssues = issueJson =>

--- a/test/graph/Graph.idr
+++ b/test/graph/Graph.idr
@@ -21,6 +21,7 @@ config =
       , orgMembers        = ["sam", "gretta", "florence"]
       , ignoredPRs        = []
       , githubPAT         = Nothing
+      , githubUser        = Nothing
       , theme             = Dark
       , ephemeral         = MkEphem "path/to/repo" False 200 Nothing
       }


### PR DESCRIPTION
<!--
## GitHub Issue
make quick only issues
--

-->
Make the quick command's issue-number auto-completion only show issues, not PRs (which are technically issues as well).

Closes #252

While I am in there, also tweak the sorting and descriptions of issue auto-completions so that the first suggestions are most likely to be the ones the user wants to find.
