### PR TITLE
better pr trees

### DIFF
--- a/src/Commands.idr
+++ b/src/Commands.idr
@@ -148,7 +148,7 @@ export
 pr : Config => Octokit =>
      (args : List PrArg)
   -> Promise' ()
-pr args = do
+pr @{config} args = do
   when conflictingDraftReadyArgs $
     reject "You cannot set a PR as ready for review and mark it as a draft at the same time."
   Actual actionTaken pr <- identifyOrCreatePR {markAsDraft} {intoBranch} !currentBranch
@@ -198,7 +198,15 @@ pr args = do
     printPrTree : PullRequest -> Promise' ()
     printPrTree pr = do
       (prs, terminalBranch) <- prChain (limit 10) pr.baseRef
-      putStrLn $ renderPrTree Nothing (pr :: prs) terminalBranch
+      let format = if config.colors then Pretty else Plain
+      putStrLn $ renderPrTree config.theme
+                              (Shell format)
+                              config.org
+                              config.repo
+                              Nothing
+                              Nothing
+                              (pr :: prs)
+                              terminalBranch
 
 ||| Request review from the given teams & users as reviewers when the user executes
 ||| `harmony request ...`.

--- a/src/Commands/PullRequest.idr
+++ b/src/Commands/PullRequest.idr
@@ -26,9 +26,10 @@ import Language.JSON.Accessors
 import System
 import System.File
 import System.Git
+import Theme
 import Util
-import Util.Jira
 import Util.Github
+import Util.Jira
 
 import Text.PrettyPrint.Prettyprinter
 import Text.PrettyPrint.Prettyprinter.Render.Terminal
@@ -305,6 +306,12 @@ prChain @{config} (More fuel) branch =
                | [] => pure ([], branch)
              mapFst (prForBranch ::) <$> prChain fuel prForBranch.baseRef
 
+public export
+data ShellFormat = Pretty | Plain
+
+public export
+data RenderFormat = Markdown | Shell ShellFormat
+
 ||| Render a PR tree.
 |||
 ||| If you pass `branch`, that is the leaf of the tree. All PRs between that
@@ -312,20 +319,57 @@ prChain @{config} (More fuel) branch =
 ||| terminal branch (e.g. the `mainBranch` of the repo, usually) gets passed in
 ||| last.
 export
-renderPrTree : (branch : Maybe String) -> List PullRequest -> (terminalBranch : String) -> String
-renderPrTree branch prs terminalBranch = 
-  "● `\{terminalBranch}`" ++ "\n" ++ go indentIncrement (reverse prs) branch 
+renderPrTree : Theme -> RenderFormat -> (org : String) -> (repo : String) -> (branch : Maybe String) -> (title : Maybe String) -> List PullRequest -> (terminalBranch : String) -> String
+renderPrTree t format org repo branch title prs terminalBranch = 
+  (formattedBranchLine 0 terminus terminalBranch Nothing)  ++ "\n" ++ go 1 (reverse prs) branch
 
   where
     indentIncrement : Nat
     indentIncrement = 4
 
+    terminus : String
+    terminus = "⨀"
+
+    arrow : String
+    arrow = "↖"
+
+    renderPretty : Doc AnsiStyle -> String
+    renderPretty doc =
+      let formatFn = case format of
+                          (Shell Pretty) => id
+                          _ => unAnnotate
+      in renderString . layoutUnbounded $ formatFn doc
+
+    mdIndent : Nat -> String -> String
+    mdIndent i = (replicate (S i) '>' ++ " " ++)
+
+    formattedBranchLine : (indentation : Nat) -> (symbol : String) -> (branch : String) -> (title : Maybe String) -> String
+    formattedBranchLine idnt symbol branch title =
+      let title' = fromMaybe "" title
+      in case format of
+              Markdown => mdIndent idnt "\{symbol} `\{branch}`" ++ "\n" ++
+                            mdIndent idnt "**\{title'}**"
+              Shell _ => renderPretty $ 
+                           indent (cast $ 1 + idnt * indentIncrement) $ 
+                             (pretty symbol) <++> (theme' Special $ pretty branch)
+
+    formattedPrLines : (indentation : Nat) -> PullRequest -> String
+    formattedPrLines idnt pr =
+      case format of
+           Markdown => mdIndent idnt "\{arrow} `\{pr.headRef}` (\{webURI' org repo pr})" ++ "\n" ++
+                      mdIndent idnt "**\{pr.title}**"
+           Shell _  => renderPretty $
+                         indent (cast $ 1 + idnt * indentIncrement) $
+                           vsep [ (pretty arrow) <++> (theme' Data (pretty pr.title))
+                                , indent 2 $ "└" <++> annotate italic (pretty $ webURI' org repo pr)
+                                ]
+
     go : (indentation : Nat) -> List PullRequest -> (maybeBranch : Maybe String) -> String
     go idnt [] maybeBranch = case maybeBranch of
-                             (Just branch) => indent idnt "↖ `\{branch}`"
-                             Nothing => ""
+                                  (Just branch) => formattedBranchLine idnt arrow branch title
+                                  Nothing => ""
     go idnt (pr :: prs) branch =
-      indent idnt $ "↖ `\{pr.headRef}` (#\{show pr.number})\n" ++ go (idnt + indentIncrement) prs branch
+      (formattedPrLines idnt pr) ++ "\n" ++ go (idnt + 1) prs branch
 
 githubInferredBranchInfo : Config => Octokit => (branch : String) -> (baseBranch : String) -> Promise' BranchInferredData
 githubInferredBranchInfo @{config} branch baseBranch =
@@ -345,11 +389,18 @@ githubInferredBranchInfo @{config} branch baseBranch =
     relatedToPrefix : (issueNumber : String) -> String
     relatedToPrefix issueNumber = "Related to #\{issueNumber}"
 
-    maybePrTree : Promise' String
-    maybePrTree =
+    maybePrTree : Issue -> Promise' String
+    maybePrTree issue =
       if config.addPrTreeDescription && (baseBranch /= config.mainBranch)
          then do (prs, terminalBranch) <- prChain (limit 10) baseBranch
-                 let tree = renderPrTree (Just branch) prs terminalBranch
+                 let tree = renderPrTree config.theme 
+                                         Markdown
+                                         config.org
+                                         config.repo
+                                         (Just branch)
+                                         (Just issue.title)
+                                         prs
+                                         terminalBranch
                  pure """
                       ## PR Tree
                       \{tree}
@@ -359,7 +410,7 @@ githubInferredBranchInfo @{config} branch baseBranch =
 
     issueDescriptionPrefix : Issue -> Promise' String
     issueDescriptionPrefix issue = do
-      maybeTree <- maybePrTree
+      maybeTree <- maybePrTree issue
       pure """
         <!--
         \{maybeTree}

--- a/src/Commands/PullRequest/Test.idr
+++ b/src/Commands/PullRequest/Test.idr
@@ -1,8 +1,11 @@
 module Commands.PullRequest.Test
 
-import Data.PullRequest
 import Data.Date
+import Data.PullRequest
+import Data.Theme
+
 import Commands.PullRequest
+
 import TTest
 
 namespace PrCreationUrl
@@ -13,26 +16,29 @@ namespace PrCreationUrl
   withIntoBranch = Refl
 
 namespace RenderPrTree
-  noPrs : renderPrTree (Just "feature-1") [] "main" ==> """
-                                                        ● `main`
-                                                            ↖ `feature-1`
-                                                        """
+  noPrs : renderPrTree Dark Markdown "org" "repo" (Just "feature-1") Nothing [] "main"
+            ==> """
+                ● `main`
+                    ↖ `feature-1`
+                """
   noPrs = MkTTest
 
   mkPr : Integer -> String -> PullRequest
   mkPr num headRef = MkPullRequest num "" (MkDate 2025 01 01) False "" Open [] headRef ""
 
-  onePr : renderPrTree (Just "feature-2") [mkPr 123 "feature-1"] "main" ==> """
-                                                                            ● `main`
-                                                                                ↖ `feature-1` (#123)
-                                                                                    ↖ `feature-2`
-                                                                            """
+  onePr : renderPrTree Dark Markdown "org" "repo"  (Just "feature-2") Nothing [mkPr 123 "feature-1"] "main"
+            ==> """
+                ● `main`
+                    ↖ `feature-1` (#123)
+                        ↖ `feature-2`
+                """
   onePr = MkTTest
 
-  onePrNoLeaf : renderPrTree Nothing [mkPr 123 "feature-1"] "main" ==> """
-                                                                       ● `main`
-                                                                           ↖ `feature-1` (#123)
-                                                                       
-                                                                       """
+  onePrNoLeaf : renderPrTree Dark Markdown "org" "repo" Nothing Nothing [mkPr 123 "feature-1"] "main"
+                  ==> """
+                      ● `main`
+                          ↖ `feature-1` (#123)
+                      
+                      """
   onePrNoLeaf = MkTTest
 

--- a/src/Data/PullRequest.idr
+++ b/src/Data/PullRequest.idr
@@ -70,8 +70,12 @@ Show PullRequest where
       authorString = padRight 15 ' ' $ show author
 
 export
+webURI' : (org, repo : String) -> PullRequest -> String
+webURI' org repo pr = "https://github.com/\{org}/\{repo}/pull/\{show pr.number}"
+
+export
 (.webURI) : Config => PullRequest -> String
-pr.webURI @{config} = "https://github.com/\{config.org}/\{config.repo}/pull/\{show pr.number}"
+pr.webURI @{config} = webURI' config.org config.repo pr
 
 export
 isAuthor : String -> PullRequest -> Bool

--- a/src/Theme.idr
+++ b/src/Theme.idr
@@ -1,7 +1,7 @@
 module Theme
 
 import Data.Config
-import Data.Theme
+import public Data.Theme
 import Text.PrettyPrint.Prettyprinter
 import Text.PrettyPrint.Prettyprinter.Render.Terminal
 
@@ -24,24 +24,25 @@ cs (_ :: _ :: _ :: _) @{(Right Refl)} impossible
 ||| character being drawn is small so a different color choice might
 ||| be useful for visibility.
 public export
-data SemanticColor : Colors -> Colors -> Type where
-  Good       : SemanticColor (cs [Green ]) (cs [Green])
-  NotGreat   : SemanticColor (cs [Yellow]) (cs [Black])
-  Bad        : SemanticColor (cs [Red   ]) (cs [Red])
-  Completed  : SemanticColor (cs [Green ]) (cs [Green])
-  Completed' : SemanticColor (cs [Green ]) (cs [Black])
-  Pending    : SemanticColor (cs [Yellow]) (cs [Yellow])
-  Pending'   : SemanticColor (cs [Yellow]) (cs [Black])
-  Missed     : SemanticColor (cs [Red   ]) (cs [Red])
-  Data       : SemanticColor (cs [Green ]) (cs [Blue])
+data SemanticColor : (darkTheme : Colors) -> (lightTheme : Colors) -> Type where
+  -- desirability
+  Good       : SemanticColor (cs [Green  ]) (cs [Green])
+  NotGreat   : SemanticColor (cs [Yellow ]) (cs [Black])
+  Bad        : SemanticColor (cs [Red    ]) (cs [Red])
+  -- completion
+  Completed  : SemanticColor (cs [Green  ]) (cs [Green])
+  Completed' : SemanticColor (cs [Green  ]) (cs [Black])
+  Pending    : SemanticColor (cs [Yellow ]) (cs [Yellow])
+  Pending'   : SemanticColor (cs [Yellow ]) (cs [Black])
+  Missed     : SemanticColor (cs [Red    ]) (cs [Red])
+  -- categorization
+  Data       : SemanticColor (cs [Green  ]) (cs [Blue])
+  Special    : SemanticColor (cs [Magenta]) (cs [Magenta])
 
 public export
-theme : Config => {d, l : _} -> SemanticColor d l -> Doc AnsiStyle -> Doc AnsiStyle
-theme @{config} = go configTheme
+theme' : Theme => {d, l : _} -> SemanticColor d l -> Doc AnsiStyle -> Doc AnsiStyle
+theme' @{theme} = go theme
   where
-    configTheme : Theme
-    configTheme = config.theme
-
     maybeAnnotate : (Color -> AnsiStyle) -> Maybe Color -> Doc AnsiStyle -> Doc AnsiStyle
     maybeAnnotate s c = maybe id (annotate . s) c
 
@@ -51,4 +52,8 @@ theme @{config} = go configTheme
     go : Theme -> {dark, light : _} -> SemanticColor dark light -> Doc AnsiStyle -> Doc AnsiStyle
     go Dark _  = colorsAnn dark
     go Light _ = colorsAnn light
+
+public export
+theme : Config => {d, l : _} -> SemanticColor d l -> Doc AnsiStyle -> Doc AnsiStyle
+theme @{config} = theme' @{config.theme}
 


### PR DESCRIPTION
<!--
## PR Tree

## GitHub Issue
option to build PR chain in PR description if into branch is not root/default branch
--
It'd be sweet to build something automatically

`harmony pr --into a/b/c`

Such that `a/b/c` is a branch that has a PR into `feature-a` which has a PR into `main`

Would get you:
```
 `main`
    ↖ `feature-a` 
        ↖ `a/b/c` 
```
-->
> ⨀ `main`
> ****
>> ↖ `feature/261/ption-to-build-pr-chain-in-pr-description` (https://github.com/mattpolzin/harmony/pull/263)
>> **option to build PR chain in PR description if into branch is not root/default branch**
>>> ↖ `feature/261/better-trees`
>>> **option to build PR chain in PR description if into branch is not root/default branch**

Related to #261
