### PR TITLE
Creates issue alongside pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ organization.
 
 Running `harmony list <team>` will list the members of the given GitHub Team.
 
-## `pr [--draft | --ready] [-i/--into {<branch-name>}] [-o/--output {format}] [--print-tree] [#label, ...]`
+## `pr [--draft | --ready] [--issue] [-i/--into {<branch-name>}] [-o/--output {format}] [--print-tree] [#label, ...]`
 With a branch checked out will reach out to GitHub to determine if there is an
 open PR for that branch. If there is a PR, Harmony will print a URI that can be
 used to view the PR. If there is not a PR, Harmony will help you create one. The
@@ -351,6 +351,11 @@ downstream PRs instead of just printing the URI for the current branch's PR. New
 and existing PRs can be marked as drafts by specifying the `--draft` flag with
 the `pr` command or they can be marked as ready for review with the `--ready`
 flag. The default behavior for new PRs is to mark them ready.
+
+When creating a new PR interactively, `--issue` creates a GitHub issue first,
+uses its title as the default PR title, and adds the usual `Related to #N` link
+to the PR body. `--issue` only works for new PRs; existing PRs need issue
+association handled separately for now.
 
 By default this command outputs to a shell format that is colored (if supported)
 but you can use the `--output markdown` option to output to a markdown syntax
@@ -379,7 +384,8 @@ For example, `harmony pr #backport #bugfix` would create a PR and apply the
 
 If you are using harmony from a script or some other environment without TTY
 support, harmony will print a GitHub URL that can be used to create the PR. This
-mode of operation will ignore the `--draft` and `#label` options.
+mode of operation will ignore the `--draft` and `#label` options. `--issue` is
+interactive-only because it prompts for issue details.
 
 Many operating systems have an `open` command (though the name "open" is not
 ubiquitous); this means you can run something like `open $(harmony pr)` to open
@@ -400,6 +406,11 @@ Create a pull request that will merge into the hypothetical pre-existing
 `release/2_0` branch:
 ```shell
 harmony pr --into release/2_0
+```
+
+Create a GitHub issue and then create a PR linked to that issue:
+```shell
+harmony pr --issue
 ```
 
 ## `quick [--bugfix] [issue-title | #<issue-number>] [...]`
@@ -492,4 +503,3 @@ Print Harmony's version.
 
 ## `whoami`
 Print information about the currently configured and authenticated user.
-

--- a/docs/_4_0_SUBCOMMANDS.md
+++ b/docs/_4_0_SUBCOMMANDS.md
@@ -135,7 +135,7 @@ organization.
 
 Running `harmony list <team>` will list the members of the given GitHub Team.
 
-## `pr [--draft | --ready] [-i/--into {<branch-name>}] [-o/--output {format}] [--print-tree] [#label, ...]`
+## `pr [--draft | --ready] [--issue] [-i/--into {<branch-name>}] [-o/--output {format}] [--print-tree] [#label, ...]`
 With a branch checked out will reach out to GitHub to determine if there is an
 open PR for that branch. If there is a PR, Harmony will print a URI that can be
 used to view the PR. If there is not a PR, Harmony will help you create one. The
@@ -145,6 +145,11 @@ downstream PRs instead of just printing the URI for the current branch's PR. New
 and existing PRs can be marked as drafts by specifying the `--draft` flag with
 the `pr` command or they can be marked as ready for review with the `--ready`
 flag. The default behavior for new PRs is to mark them ready.
+
+When creating a new PR interactively, `--issue` creates a GitHub issue first,
+uses its title as the default PR title, and adds the usual `Related to #N` link
+to the PR body. `--issue` only works for new PRs; existing PRs need issue
+association handled separately for now.
 
 By default this command outputs to a shell format that is colored (if supported)
 but you can use the `--output markdown` option to output to a markdown syntax
@@ -173,7 +178,8 @@ For example, `harmony pr #backport #bugfix` would create a PR and apply the
 
 If you are using harmony from a script or some other environment without TTY
 support, harmony will print a GitHub URL that can be used to create the PR. This
-mode of operation will ignore the `--draft` and `#label` options.
+mode of operation will ignore the `--draft` and `#label` options. `--issue` is
+interactive-only because it prompts for issue details.
 
 Many operating systems have an `open` command (though the name "open" is not
 ubiquitous); this means you can run something like `open $(harmony pr)` to open
@@ -194,6 +200,11 @@ Create a pull request that will merge into the hypothetical pre-existing
 `release/2_0` branch:
 ```shell
 harmony pr --into release/2_0
+```
+
+Create a GitHub issue and then create a PR linked to that issue:
+```shell
+harmony pr --issue
 ```
 
 ## `quick [--bugfix] [issue-title | #<issue-number>] [...]`
@@ -286,4 +297,3 @@ Print Harmony's version.
 
 ## `whoami`
 Print information about the currently configured and authenticated user.
-

--- a/man/harmony.1
+++ b/man/harmony.1
@@ -349,7 +349,7 @@ configured GitHub organization.
 .PP
 Running \f[CR]harmony list <team>\f[R] will list the members of the
 given GitHub Team.
-.SS \f[CR]pr [\-\-draft | \-\-ready] [\-i/\-\-into {<branch\-name>}] [\-o/\-\-output {format}] [\-\-print\-tree] [#label, ...]\f[R]
+.SS \f[CR]pr [\-\-draft | \-\-ready] [\-\-issue] [\-i/\-\-into {<branch\-name>}] [\-o/\-\-output {format}] [\-\-print\-tree] [#label, ...]\f[R]
 With a branch checked out will reach out to GitHub to determine if there
 is an open PR for that branch.
 If there is a PR, Harmony will print a URI that can be used to view the
@@ -363,6 +363,12 @@ New and existing PRs can be marked as drafts by specifying the
 \f[CR]\-\-draft\f[R] flag with the \f[CR]pr\f[R] command or they can be
 marked as ready for review with the \f[CR]\-\-ready\f[R] flag.
 The default behavior for new PRs is to mark them ready.
+.PP
+When creating a new PR interactively, \f[CR]\-\-issue\f[R] creates a
+GitHub issue first, uses its title as the default PR title, and adds the
+usual \f[CR]Related to #N\f[R] link to the PR body.
+\f[CR]\-\-issue\f[R] only works for new PRs; existing PRs need issue
+association handled separately for now.
 .PP
 By default this command outputs to a shell format that is colored (if
 supported) but you can use the \f[CR]\-\-output markdown\f[R] option to
@@ -399,6 +405,8 @@ TTY support, harmony will print a GitHub URL that can be used to create
 the PR.
 This mode of operation will ignore the \f[CR]\-\-draft\f[R] and
 \f[CR]#label\f[R] options.
+\f[CR]\-\-issue\f[R] is interactive\-only because it prompts for issue
+details.
 .PP
 Many operating systems have an \f[CR]open\f[R] command (though the name
 \(lqopen\(rq is not ubiquitous); this means you can run something like
@@ -422,6 +430,12 @@ pre\-existing \f[CR]release/2_0\f[R] branch:
 .IP
 .EX
 harmony pr \-\-into release/2_0
+.EE
+.PP
+Create a GitHub issue and then create a PR linked to that issue:
+.IP
+.EX
+harmony pr \-\-issue
 .EE
 .SS \f[CR]quick [\-\-bugfix] [issue\-title | #<issue\-number>] [...]\f[R]
 Helps you create a new GitHub issue and a branch to work on that issue

--- a/src/Commands.idr
+++ b/src/Commands.idr
@@ -182,8 +182,6 @@ pr : Config => Octokit =>
 pr @{config} args = do
   when conflictingDraftReadyArgs $
     reject "You cannot set a PR as ready for review and mark it as a draft at the same time."
-  when conflictingIssueReadyArgs $
-    reject "You cannot create an issue for a new PR and mark an existing PR ready for review at the same time."
   Actual actionTaken pr <- identifyOrCreatePR {markAsDraft} {createIssueForPR} {intoBranch} !currentBranch
     | Hypothetical url => putStrLn url
   case actionTaken of
@@ -220,9 +218,6 @@ pr @{config} args = do
 
     conflictingDraftReadyArgs : Bool
     conflictingDraftReadyArgs = markAsDraft && markAsReady
-
-    conflictingIssueReadyArgs : Bool
-    conflictingIssueReadyArgs = createIssueForPR && markAsReady
 
     labelSlugs : List String
     labelSlugs = foldr (\case (Label l) => (l ::); _ => id) [] args

--- a/src/Commands.idr
+++ b/src/Commands.idr
@@ -77,13 +77,13 @@ label @{config} labels =
 
 prUsageError  : String
 prUsageError = 
-  "pr's arguments must be #<label>, --into <branch-name>, --ready, or --draft to create a draft PR."
+  "pr's arguments must be #<label>, --into <branch-name>, --ready, --draft, or --issue."
 
 data IntoOpt = Branch (Exists String.NonEmpty)
 
 data OutputFormat = Shell | Markdown
 
-data PrArg = Draft | Ready | PrintTree | Output OutputFormat | Into IntoOpt | Label String
+data PrArg = Draft | Ready | CreateIssue | PrintTree | Output OutputFormat | Into IntoOpt | Label String
 
 (<||>) : Alternative t => (a -> t b) -> (a -> t b) -> a -> t b
 (<||>) f g x = f x <|> g x
@@ -99,7 +99,7 @@ parsePrArgs args =
       intoArgs' = Into <$> intoArgs
       (outputArgs, rest') = recombineOutputArgs rest
       outputArgs' = Output <$> outputArgs
-      rest'' = (traverse (parseReadyFlag <||> parseDraftFlag <||> parsePrintTreeFlag <||> parseLabelArg) rest')
+      rest'' = (traverse (parseReadyFlag <||> parseDraftFlag <||> parseIssueFlag <||> parsePrintTreeFlag <||> parseLabelArg) rest')
       in  maybeToEither prUsageError ((intoArgs' ++ outputArgs' ++) <$> rest'')
   where
     parseDraftFlag : String -> Maybe PrArg
@@ -109,6 +109,10 @@ parsePrArgs args =
     parseReadyFlag : String -> Maybe PrArg
     parseReadyFlag "--ready" = Just Ready
     parseReadyFlag _ = Nothing
+
+    parseIssueFlag : String -> Maybe PrArg
+    parseIssueFlag "--issue" = Just CreateIssue
+    parseIssueFlag _ = Nothing
 
     parsePrintTreeFlag : String -> Maybe PrArg
     parsePrintTreeFlag "--print-tree" = Just PrintTree
@@ -178,7 +182,9 @@ pr : Config => Octokit =>
 pr @{config} args = do
   when conflictingDraftReadyArgs $
     reject "You cannot set a PR as ready for review and mark it as a draft at the same time."
-  Actual actionTaken pr <- identifyOrCreatePR {markAsDraft} {intoBranch} !currentBranch
+  when conflictingIssueReadyArgs $
+    reject "You cannot create an issue for a new PR and mark an existing PR ready for review at the same time."
+  Actual actionTaken pr <- identifyOrCreatePR {markAsDraft} {createIssueForPR} {intoBranch} !currentBranch
     | Hypothetical url => putStrLn url
   case actionTaken of
        Identified => if printTree then printPrTree pr else putStrLn pr.webURI
@@ -209,8 +215,14 @@ pr @{config} args = do
     markAsReady : Bool
     markAsReady = isJust $ find (\case Ready => True; _ => False) args
 
+    createIssueForPR : Bool
+    createIssueForPR = isJust $ find (\case CreateIssue => True; _ => False) args
+
     conflictingDraftReadyArgs : Bool
     conflictingDraftReadyArgs = markAsDraft && markAsReady
+
+    conflictingIssueReadyArgs : Bool
+    conflictingIssueReadyArgs = createIssueForPR && markAsReady
 
     labelSlugs : List String
     labelSlugs = foldr (\case (Label l) => (l ::); _ => id) [] args

--- a/src/Commands/Help.idr
+++ b/src/Commands/Help.idr
@@ -75,8 +75,9 @@ subcommandHelp' n@"config" = subcommand n [argument True "<property>", argument 
   ]
 subcommandHelp' n@"pr" = subcommand n [ argument False "--ready"
                                       , argument False "--draft"
+                                      , argument False "--issue"
                                       , argument False "-i/--into {<branch-name>}"
-                                      , argument False "--print-result"
+                                      , argument False "--print-tree"
                                       , argument False "-o/--output {format}"
                                       , argument False "#<label>"
                                       , argument False "..."] $
@@ -84,6 +85,7 @@ subcommandHelp' n@"pr" = subcommand n [ argument False "--ready"
   , reflow "Optionally apply any number of labels by prefixing them with '#'."
   , reflow "Optionally mark a new or existing PR as a draft with the --draft flag."
   , reflow "Optionally mark an existing PR as ready for review with the --ready flag."
+  , reflow "Optionally create and link a GitHub Issue with --issue."
   , reflow "Optionally specify the branch to merge into with the --into option."
   , reflow "Optionally print a pr tree with the --print-tree flag."
   , reflow "Optionally output in markdown or shell (default) format."
@@ -221,4 +223,3 @@ help useDecorations terminalColumns =
   let decorate = if useDecorations then id else unAnnotate
   in  renderString . layoutPretty (optionsWithBestWidth terminalColumns) $
         decorate helpDocs
-

--- a/src/Commands/PullRequest.idr
+++ b/src/Commands/PullRequest.idr
@@ -1,6 +1,7 @@
 module Commands.PullRequest
 
 import Commands.Reviewer
+import Commands.Quick
 
 import Data.Config
 import Data.Either
@@ -541,15 +542,23 @@ prCreationUrl org repo branch intoBranch =
 export
 identifyOrCreatePR : Config => Octokit => 
                      {default False markAsDraft : Bool}
+                  -> {default False createIssueForPR : Bool}
                   -> {default Nothing intoBranch : Maybe String}
                   -> (branch : String) 
                   -> Promise' CreatePRResult
-identifyOrCreatePR @{config} {markAsDraft} {intoBranch} branch = do
+identifyOrCreatePR @{config} {markAsDraft} {createIssueForPR} {intoBranch} branch = do
   [openPr] <- listPRsForBranch config.org config.repo branch
-    | [] => case !(isTTY stdout) of
-               True  => Actual Created <$> createPR
-               False => pure (Hypothetical $ prCreationUrl config.org config.repo branch intoBranch)
+    | [] => do
+        when (createIssueForPR && isJust (parseGithubIssueNumber branch)) $
+          reject "The current branch already appears to reference a GitHub issue; --issue would create a duplicate issue."
+        case !(isTTY stdout) of
+             True  => Actual Created <$> createPR
+             False => if createIssueForPR
+                         then reject "The --issue option requires an interactive terminal because Harmony needs to prompt for issue details."
+                         else pure (Hypothetical $ prCreationUrl config.org config.repo branch intoBranch)
     | _  => reject "Multiple PRs for the current brach. Harmony only handles 1 PR per branch currently."
+  when createIssueForPR $
+    reject "The --issue option is only supported when creating a new PR."
   pure (Actual Identified openPr)
     where
       continueGivenUncommittedChanges : Promise' Bool
@@ -632,10 +641,23 @@ identifyOrCreatePR @{config} {markAsDraft} {intoBranch} branch = do
 
         baseBranch <- getBaseBranch intoBranch inferredBranchInfo.baseBranchGuess
 
-        let titlePrefix = fromMaybe "" inferredBranchInfo.titlePrefix
-        bodyPrefix <- maybe (pure "") ($ baseBranch) inferredBranchInfo.buildBodyPrefix
+        let issueForPrPromise : Promise' (Maybe Issue)
+            issueForPrPromise =
+              if createIssueForPR
+                 then Just <$> createNewIssueWithMessage "Creating a new GitHub issue for this PR." baseBranch Nothing
+                 else pure Nothing
+        issueForPr <- issueForPrPromise
 
-        title <- (titlePrefix ++) <$> (prTitlePrompt inferredBranchInfo.defaultTitle)
+        let titlePrefix = fromMaybe "" inferredBranchInfo.titlePrefix
+        bodyPrefix <- case issueForPr of
+                           Just issue => buildIssueBodyPrefix branch issue baseBranch
+                           Nothing => maybe (pure "") ($ baseBranch) inferredBranchInfo.buildBodyPrefix
+
+        let defaultTitle = case issueForPr of
+                                Just issue => Just issue.title
+                                Nothing => inferredBranchInfo.defaultTitle
+
+        title <- (titlePrefix ++) <$> (prTitlePrompt defaultTitle)
 
         -- either get the description at the command line or open an editor
         -- with a template if available

--- a/src/Commands/PullRequest.idr
+++ b/src/Commands/PullRequest.idr
@@ -292,6 +292,46 @@ record BranchInferredData where
 noInferredData : BranchInferredData
 noInferredData = MkInferredData Nothing Nothing Nothing Nothing
 
+export
+relatedToPrefix : (issueNumber : String) -> String
+relatedToPrefix issueNumber = "Related to #\{issueNumber}"
+
+titlePrefixForBranch : Config => (branch : String) -> String
+titlePrefixForBranch @{config} branch =
+  if isBugfixBranch branch
+     then maybe "" (++ " ") config.bugfixPRTitlePrefix
+     else ""
+
+removeCommentOpenTag : String -> String
+removeCommentOpenTag str =
+  if "<!--" `isPrefixOf` str
+     then drop 4 str
+     else str
+
+removeCommentTags : String -> String
+removeCommentTags = unlines . map removeCommentOpenTag . filter (/= "-->") . lines
+
+issueDescriptionPrefix : (maybeTree : String) -> Issue -> String
+issueDescriptionPrefix maybeTree issue =
+  """
+  <!--
+  \{maybeTree}
+  ## GitHub Issue
+  \{issue.title}
+  --
+  \{removeCommentTags issue.body}
+  -->
+  """
+
+export
+issueBodyPrefix : (maybeTree : String) -> Issue -> String
+issueBodyPrefix maybeTree issue =
+  """
+  \{issueDescriptionPrefix maybeTree issue}
+
+  \{relatedToPrefix (show issue.number)}
+  """
+
 ||| Get the chain of PRs that lead from the given branch to the configured
 ||| mainBranch or any other terminal branch along the way. The list will be in
 ||| merge-order. The list does not contain the mainBranch (or any other branch
@@ -419,14 +459,23 @@ renderPrTree @{config} format =
                         , indent 2 $ "└" <++> annotate italic (pretty uri)
                         ]
 
-removeCommentOpenTag : String -> String
-removeCommentOpenTag str =
-  if "<!--" `isPrefixOf` str
-     then drop 4 str
-     else str
+maybePrTree : Config => Octokit => (branch : String) -> Issue -> (baseBranch : String) -> Promise' String
+maybePrTree @{config} branch issue baseBranch =
+  if config.addPrTreeDescription && (baseBranch /= config.mainBranch)
+     then do (prs, terminalBranch) <- upstreamPrChain (limit 10) baseBranch
+             let nodes = prTree (Just branch) (Just issue.title) [] prs terminalBranch
+             let tree = renderPrTree Markdown nodes
+             pure """
+                  ## PR Tree
+                  \{tree}
+                  """
+     else pure ""
 
-removeCommentTags : String -> String
-removeCommentTags = unlines . map removeCommentOpenTag . filter (/= "-->") . lines
+export
+buildIssueBodyPrefix : Config => Octokit => (branch : String) -> Issue -> (baseBranch : String) -> Promise' String
+buildIssueBodyPrefix branch issue baseBranch = do
+  tree <- maybePrTree branch issue baseBranch
+  pure $ issueBodyPrefix tree issue
 
 githubInferredBranchInfo : Config => Octokit => (branch : String) -> Promise' BranchInferredData
 githubInferredBranchInfo @{config} branch =
@@ -436,57 +485,13 @@ githubInferredBranchInfo @{config} branch =
       issue <- getIssue config.org config.repo issueNum
       pure $ 
         MkInferredData Nothing 
-                       (Just $ buildBodyPrefix issue)
-                       (Just $ titlePrefix ++ issue.title)
+                       (Just $ buildIssueBodyPrefix branch issue)
+                       (Just $ titlePrefixForBranch branch ++ issue.title)
                        issue.baseBranchGuess
 
   where
     issueNumber : Maybe String
     issueNumber = parseGithubIssueNumber branch
-
-    relatedToPrefix : (issueNumber : String) -> String
-    relatedToPrefix issueNumber = "Related to #\{issueNumber}"
-
-    maybePrTree : Issue -> (baseBranch : String) -> Promise' String
-    maybePrTree issue baseBranch =
-      if config.addPrTreeDescription && (baseBranch /= config.mainBranch)
-         then do (prs, terminalBranch) <- upstreamPrChain (limit 10) baseBranch
-                 let nodes = prTree (Just branch) (Just issue.title) [] prs terminalBranch
-                 let tree = renderPrTree Markdown nodes
-                 pure """
-                      ## PR Tree
-                      \{tree}
-                      """
-         else pure ""
-
-    titlePrefix : String
-    titlePrefix =
-      if isBugfixBranch branch
-         then maybe "" (++ " ") config.bugfixPRTitlePrefix
-         else ""
-
-    issueDescriptionPrefix : Issue -> (baseBranch : String) -> Promise' String
-    issueDescriptionPrefix issue baseBranch = do
-      maybeTree <- maybePrTree issue baseBranch
-      pure """
-        <!--
-        \{maybeTree}
-        ## GitHub Issue
-        \{issue.title}
-        --
-        \{removeCommentTags issue.body}
-        -->
-        """
-
-    buildBodyPrefix : Issue -> (baseBranch : String) -> Promise' String
-    buildBodyPrefix issue baseBranch = do
-      part1 <- issueDescriptionPrefix issue baseBranch
-      let part2 = relatedToPrefix (show issue.number)
-      pure $ """
-             \{part1}
-
-             \{part2}
-             """
 
 ||| Get any inferred title prefix, body prefix, or default title from the
 ||| current branch.
@@ -644,4 +649,3 @@ identifyOrCreatePR @{config} {markAsDraft} {intoBranch} branch = do
         putStrLn branch
 
         GitHub.createPR {markAsDraft} config.org config.repo branch baseBranch title description
-

--- a/src/Commands/PullRequest.idr
+++ b/src/Commands/PullRequest.idr
@@ -293,7 +293,6 @@ record BranchInferredData where
 noInferredData : BranchInferredData
 noInferredData = MkInferredData Nothing Nothing Nothing Nothing
 
-export
 relatedToPrefix : (issueNumber : String) -> String
 relatedToPrefix issueNumber = "Related to #\{issueNumber}"
 
@@ -324,7 +323,6 @@ issueDescriptionPrefix maybeTree issue =
   -->
   """
 
-export
 issueBodyPrefix : (maybeTree : String) -> Issue -> String
 issueBodyPrefix maybeTree issue =
   """
@@ -460,23 +458,22 @@ renderPrTree @{config} format =
                         , indent 2 $ "└" <++> annotate italic (pretty uri)
                         ]
 
-maybePrTree : Config => Octokit => (branch : String) -> Issue -> (baseBranch : String) -> Promise' String
-maybePrTree @{config} branch issue baseBranch =
-  if config.addPrTreeDescription && (baseBranch /= config.mainBranch)
-     then do (prs, terminalBranch) <- upstreamPrChain (limit 10) baseBranch
-             let nodes = prTree (Just branch) (Just issue.title) [] prs terminalBranch
-             let tree = renderPrTree Markdown nodes
-             pure """
-                  ## PR Tree
-                  \{tree}
-                  """
-     else pure ""
-
-export
 buildIssueBodyPrefix : Config => Octokit => (branch : String) -> Issue -> (baseBranch : String) -> Promise' String
-buildIssueBodyPrefix branch issue baseBranch = do
-  tree <- maybePrTree branch issue baseBranch
+buildIssueBodyPrefix @{config} branch issue baseBranch = do
+  tree <- maybePrTree
   pure $ issueBodyPrefix tree issue
+  where
+    maybePrTree : Promise' String
+    maybePrTree =
+      if config.addPrTreeDescription && (baseBranch /= config.mainBranch)
+         then do (prs, terminalBranch) <- upstreamPrChain (limit 10) baseBranch
+                 let nodes = prTree (Just branch) (Just issue.title) [] prs terminalBranch
+                 let tree = renderPrTree Markdown nodes
+                 pure """
+                      ## PR Tree
+                      \{tree}
+                      """
+         else pure ""
 
 githubInferredBranchInfo : Config => Octokit => (branch : String) -> Promise' BranchInferredData
 githubInferredBranchInfo @{config} branch =

--- a/src/Commands/PullRequest/Test.idr
+++ b/src/Commands/PullRequest/Test.idr
@@ -23,6 +23,10 @@ namespace RemoveCommentTags
   withTags : removeCommentTags "<!-- Hello.\nHi Hello\n-->\n" ==> " Hello.\nHi Hello\n"
   withTags = MkTTest
 
+namespace IssueBodyPrefix
+  relatedToPrefixTest : relatedToPrefix "123" === "Related to #123"
+  relatedToPrefixTest = Refl
+
 namespace RenderPrTree
   config : Config
   config =
@@ -134,4 +138,3 @@ namespace RenderPrTree
 
                       """
   onePrAboveOneBelowNoLeafShell = MkTTest
-

--- a/src/Commands/Quick.idr
+++ b/src/Commands/Quick.idr
@@ -27,13 +27,15 @@ dasherize = pack . replaceOn ' ' '-' . unpack
 branchNameSuggestion : String -> String
 branchNameSuggestion = toLower . dasherize
 
-createNewIssue : Config =>
-                 Octokit =>
-                 (baseBranchGuess : String)
-              -> (issueTitle : Maybe String)
-              -> Promise' Issue
-createNewIssue @{config} baseBranchGuess issueTitle' = do
-  putStrLn "Creating a new GitHub issue and branch."
+export
+createNewIssueWithMessage : Config =>
+                            Octokit =>
+                            (message : String)
+                         -> (baseBranchGuess : String)
+                         -> (issueTitle : Maybe String)
+                         -> Promise' Issue
+createNewIssueWithMessage @{config} message baseBranchGuess issueTitle' = do
+  putStrLn message
   putStrLn ""
 
   issueTitle <-
@@ -63,6 +65,14 @@ createNewIssue @{config} baseBranchGuess issueTitle' = do
 
                 """
            else ""
+
+export
+createNewIssue : Config =>
+                 Octokit =>
+                 (baseBranchGuess : String)
+              -> (issueTitle : Maybe String)
+              -> Promise' Issue
+createNewIssue = createNewIssueWithMessage "Creating a new GitHub issue and branch."
 
 public export
 data IssueIdent = NoInfo
@@ -99,4 +109,3 @@ quickStartNewWork @{config} issueCategory issueIdent = do
   where
     branchPrefix : String
     branchPrefix = toLower $ show issueCategory
-

--- a/src/Commands/Test.idr
+++ b/src/Commands/Test.idr
@@ -16,8 +16,14 @@ namespace ParsePrArgs
   parsesJustReadyFlag : parsePrArgs ["--ready"] === Right [Ready]
   parsesJustReadyFlag = Refl
 
+  parsesJustIssueFlag : parsePrArgs ["--issue"] === Right [CreateIssue]
+  parsesJustIssueFlag = Refl
+
   parsesJustLabels : parsePrArgs ["#one", "#two"] === Right [Label "one", Label "two"]
   parsesJustLabels = Refl
+
+  parsesIssueFlagWithDraftAndLabel : parsePrArgs ["--issue", "--draft", "#one"] === Right [CreateIssue, Draft, Label "one"]
+  parsesIssueFlagWithDraftAndLabel = Refl
 
   parsesIntoOption : parsePrArgs ["--into", "a"] === Right [Into (Branch (Evidence "a" (IsNonEmpty "a")))]
   parsesIntoOption = Refl

--- a/src/ShellCompletion/Common.idr
+++ b/src/ShellCompletion/Common.idr
@@ -56,6 +56,7 @@ allPrCmdOptsAndDescriptions : List (String, String)
 allPrCmdOptsAndDescriptions =
   [ ("--ready"     , "mark the new or existing PR as ready for review")
   , ("--draft"     , "mark the new or existing PR as a draft")
+  , ("--issue"     , "create and link a GitHub Issue")
   , ("--print-tree", "print a tree of PRs between the current branch and the main branch")
   , ("--output"    , "output in the given format (at least for non-error responses)")
   , ("--into"      , "set the branch to merge your PR into")
@@ -160,10 +161,15 @@ cmdOpts s "pr" partialArg    "pr" =
         then Nothing -- <- falls through to handle with config below.
         else Just []
 cmdOpts s "pr" partialArg "--draft" =
-  someWithPrefixOrNothing partialArg (filter (\c => matches "--output" c || matches "--into" c || matches "--print-tree" c) (allPrCmdOpts s)) <|>
+  someWithPrefixOrNothing partialArg (filter (\c => matches "--output" c || matches "--into" c || matches "--issue" c || matches "--print-tree" c) (allPrCmdOpts s)) <|>
     if isHashPrefix partialArg
        then Nothing -- <- falls through to handle with config below.
        else Just [] 
+cmdOpts s "pr" partialArg "--issue" =
+  someWithPrefixOrNothing partialArg (filter (\c => matches "--output" c || matches "--into" c || matches "--draft" c || matches "--print-tree" c) (allPrCmdOpts s)) <|>
+    if isHashPrefix partialArg
+       then Nothing -- <- falls through to handle with config below.
+       else Just []
 cmdOpts s "pr" partialArg lastArg =
   let prefixMatch = 
     if isJust $ List.find (== lastArg) (fst <$> allOutputFormatOptsAndDescriptions)
@@ -364,4 +370,3 @@ githubOpts @{config} gh _ "quick" partialArg _ = do
              issues
   pure (str . mapSnd describer <$> sortBy sorter issues')
 githubOpts _ _ _ _ _ = pure []
-

--- a/src/ShellCompletion/Common.idr
+++ b/src/ShellCompletion/Common.idr
@@ -154,7 +154,7 @@ cmdOpts s "pr" "--"          "pr"       = all (allPrCmdOpts s)
 cmdOpts s "pr" "-"           "pr"       = someWithPrefix "--" (allPrCmdOpts s)
 cmdOpts _ "pr" partialBranch "--into"   = Nothing -- <- falls through to handle with config below.
 cmdOpts s "pr" partialFormat "--output" = someWithPrefix partialFormat (allOutputFormatOpts s)
-cmdOpts s "pr" _             "--ready"  = someFrom ["--print-tree", "--into", "--output"] (allPrCmdOpts s) -- The ready flag does not work with the --draft flag.
+cmdOpts s "pr" _             "--ready"  = someFrom ["--issue", "--print-tree", "--into", "--output"] (allPrCmdOpts s) -- The ready flag does not work with the --draft flag.
 cmdOpts s "pr" partialArg    "pr" = 
   someWithPrefixOrNothing partialArg (allPrCmdOpts s) <|> 
     if isHashPrefix partialArg 
@@ -166,7 +166,7 @@ cmdOpts s "pr" partialArg "--draft" =
        then Nothing -- <- falls through to handle with config below.
        else Just [] 
 cmdOpts s "pr" partialArg "--issue" =
-  someWithPrefixOrNothing partialArg (filter (\c => matches "--output" c || matches "--into" c || matches "--draft" c || matches "--print-tree" c) (allPrCmdOpts s)) <|>
+  someWithPrefixOrNothing partialArg (filter (\c => matches "--output" c || matches "--into" c || matches "--ready" c || matches "--draft" c || matches "--print-tree" c) (allPrCmdOpts s)) <|>
     if isHashPrefix partialArg
        then Nothing -- <- falls through to handle with config below.
        else Just []

--- a/test/help-command/expected
+++ b/test/help-command/expected
@@ -36,7 +36,7 @@ Subcommands:
       Labels that do not exist yet will be created automatically.
   list [<team-slug>]
       List all teams or the members of the given GitHub Team.
-  pr [--ready] [--draft] [-i/--into {<branch-name>}] [--print-result] [-o/--output {format}] [#<label>] [...]
+  pr [--ready] [--draft] [--issue] [-i/--into {<branch-name>}] [--print-tree] [-o/--output {format}] [#<label>] [...]
       Identify an existing PR or create a new one for the current branch.
 
       Optionally apply any number of labels by prefixing them with '#'.
@@ -44,6 +44,8 @@ Subcommands:
       Optionally mark a new or existing PR as a draft with the --draft flag.
 
       Optionally mark an existing PR as ready for review with the --ready flag.
+
+      Optionally create and link a GitHub Issue with --issue.
 
       Optionally specify the branch to merge into with the --into option.
 

--- a/test/tab-completion/expected
+++ b/test/tab-completion/expected
@@ -59,7 +59,8 @@ into pr suggests draft, issue, output, and print-tree args:
 --print-tree
 --output
 
-ready pr suggests into, output, and print-tree args:
+ready pr suggests issue, into, output, and print-tree args:
+--issue
 --print-tree
 --output
 --into

--- a/test/tab-completion/expected
+++ b/test/tab-completion/expected
@@ -39,20 +39,23 @@ at-mention
 
 options for bugfixPRTitlePrefix config:
 
-no args suggests print-tree, into, output, ready, and draft args:
+no args suggests print-tree, into, output, ready, draft, and issue args:
 --ready
 --draft
+--issue
 --print-tree
 --output
 --into
 
-draft pr suggests into, output, and print-tree args:
+draft pr suggests into, issue, output, and print-tree args:
+--issue
 --print-tree
 --output
 --into
 
-into pr suggests draft, output, and print-tree args:
+into pr suggests draft, issue, output, and print-tree args:
 --draft
+--issue
 --print-tree
 --output
 
@@ -61,9 +64,10 @@ ready pr suggests into, output, and print-tree args:
 --output
 --into
 
-output last arg suggests draft, into, and print-tree args:
+output last arg suggests draft, issue, into, and print-tree args:
 --ready
 --draft
+--issue
 --print-tree
 --into
 

--- a/test/tab-completion/run
+++ b/test/tab-completion/run
@@ -27,15 +27,15 @@ $harmony --bash-completion config -- bugfixPRTitlePrefix
 # pr command
 #
 echo ''
-echo 'no args suggests print-tree, into, output, ready, and draft args:'
+echo 'no args suggests print-tree, into, output, ready, draft, and issue args:'
 $harmony --bash-completion pr -- pr
 
 echo ''
-echo 'draft pr suggests into, output, and print-tree args:'
+echo 'draft pr suggests into, issue, output, and print-tree args:'
 $harmony --bash-completion pr -- --draft
 
 echo ''
-echo 'into pr suggests draft, output, and print-tree args:'
+echo 'into pr suggests draft, issue, output, and print-tree args:'
 $harmony --bash-completion pr -- main
 
 echo ''
@@ -43,7 +43,7 @@ echo 'ready pr suggests into, output, and print-tree args:'
 $harmony --bash-completion pr -- --ready
 
 echo ''
-echo 'output last arg suggests draft, into, and print-tree args:'
+echo 'output last arg suggests draft, issue, into, and print-tree args:'
 $harmony --bash-completion pr -- markdown
 
 #

--- a/test/tab-completion/run
+++ b/test/tab-completion/run
@@ -39,7 +39,7 @@ echo 'into pr suggests draft, issue, output, and print-tree args:'
 $harmony --bash-completion pr -- main
 
 echo ''
-echo 'ready pr suggests into, output, and print-tree args:'
+echo 'ready pr suggests issue, into, output, and print-tree args:'
 $harmony --bash-completion pr -- --ready
 
 echo ''


### PR DESCRIPTION
Adds `--issue` flag to `harmony pr`

When no pull request exists for the current branch, `harmony pr --issue` creates a gitHub issue first, then creates the PR with the issue linked in the PR body.

this only supports creating an issue alongside a new PR. If a PR already exists, `--issue` errors rather than trying to associate a new issue after the fact.