### PR TITLE
make "you are here" text in PR description trees more visible

### DIFF
--- a/src/Commands/PullRequest.idr
+++ b/src/Commands/PullRequest.idr
@@ -427,7 +427,7 @@ renderPrTree @{config} format =
 
     markerLines : (marked : Bool) -> List String
     markerLines False = []
-    markerLines True = ["**[[** _you are here_ **]]**"]
+    markerLines True = ["**[[** -> _you are here_ <- **]]**"]
 
     renderNode : (Nat, String) -> PrTreeNode -> (Nat, String)
     renderNode (idx, acc) (Branch symbol name title) =

--- a/src/Commands/PullRequest/Test.idr
+++ b/src/Commands/PullRequest/Test.idr
@@ -98,7 +98,7 @@ namespace RenderPrTree
                   ==> """
                       > ⨀ `main`
                       >> ↖ `feature-1` (https://github.com/org/repo/pull/123)
-                      >> **[[** _you are here_ **]]**
+                      >> **[[** -> _you are here_ <- **]]**
                       >> **Fancy PR**
 
                       """
@@ -118,7 +118,7 @@ namespace RenderPrTree
                   ==> """
                       > ⨀ `main`
                       >> ↖ `feature-1` (https://github.com/org/repo/pull/123)
-                      >> **[[** _you are here_ **]]**
+                      >> **[[** -> _you are here_ <- **]]**
                       >> **Fancy PR**
                       >>> ↖ `feature-2` (https://github.com/org/repo/pull/456)
                       >>> **Fancy PR**


### PR DESCRIPTION
<!--

## GitHub Issue
make "you are here" text in PR description trees more visible
--
I think the following text is just enough more eye-catching:

**[[** -> you are here <- **]]**

-->

Closes #311
