### PR TITLE
Update help command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Not all configuration properties can be read/set with this command.
 `githubPAT` (optional string) 
 : If the `$GITHUB_PAT` and `$GH_TOKEN` environment variables are not set, this Personal Access Token is used to authenticate with GitHub.
 
-## `contribute [options]`
+## `contribute [-c/--checkout | -l/--list] [-<num>] [-i/--ignore {<uri> | <pr-number>}]`
 Print the URI of the oldest non-draft PR waiting for your review. If you are not
 requested for review on any PRs, Harmony will suggest a PR that your review is
 not requested on.
@@ -393,8 +393,10 @@ You can specify the branch to merge into via the `--into` CLI argument if you
 want to as an alternative to the interactive prompt.
 
 You can also specify any number of labels to apply by prefixing them with '#'.
-For example, `harmony pr #backport #bugfix` would create a PR and apply the
-`backport` and `bugfix` labels.
+For example, `harmony pr \#backport \#bugfix` would create a PR and apply the
+`backport` and `bugfix` labels. Note that some shells will require you to escape
+the `#` or else it will be considered a comment and not passed to harmony as an
+argument.
 
 If you are using harmony from a script or some other environment without TTY
 support, harmony will print a GitHub URL that can be used to create the PR. This
@@ -413,7 +415,7 @@ harmony pr --draft
 
 Create a PR for the current branch and add the `urgent` label:
 ```shell
-harmony pr #urgent
+harmony pr \#urgent
 ```
 
 Create a pull request that will merge into the hypothetical pre-existing
@@ -449,13 +451,34 @@ title at the CLI then you will be prompted to enter the issue title
 interactively. You will also be prompted for the issue description interactively
 regardless.
 
+### Examples
+Create an issue and bugfix branch:
+```shell
+harmony quick --bugfix
+```
+
+Create an issue with the title 'widget fails to create' and bugfix branch:
+```shell
+harmony quick --bugfix widget fails to create
+```
+
+Create a branch for the existing issue with GitHub issue number `345`:
+```shell
+harmony quick \#345
+```
+
+Create an issue (and branch) and associate it with the 'Cool Features' project:
+```shell
+harmony quick --project "Cool Features"
+```
+
 ## `reflect`
 Show a summary of your review requests and authored pull requests.
 
 <!-- image location is intentionally relative to repository root -->
 ![Reflect Screenshot](./docs/images/reflect.png)
 
-## `request {team-slug | +user-login} [options]`
+## `request {<team-slug> | +<user-login>} [#<label>] [...]`
 Helps you create a PR if one does not exist yet and then it will request reviews
 from teams and/or users.
 

--- a/docs/_4_0_SUBCOMMANDS.md
+++ b/docs/_4_0_SUBCOMMANDS.md
@@ -45,7 +45,7 @@ Not all configuration properties can be read/set with this command.
 `githubPAT` (optional string) 
 : If the `$GITHUB_PAT` and `$GH_TOKEN` environment variables are not set, this Personal Access Token is used to authenticate with GitHub.
 
-## `contribute [options]`
+## `contribute [-c/--checkout | -l/--list] [-<num>] [-i/--ignore {<uri> | <pr-number>}]`
 Print the URI of the oldest non-draft PR waiting for your review. If you are not
 requested for review on any PRs, Harmony will suggest a PR that your review is
 not requested on.
@@ -173,8 +173,10 @@ You can specify the branch to merge into via the `--into` CLI argument if you
 want to as an alternative to the interactive prompt.
 
 You can also specify any number of labels to apply by prefixing them with '#'.
-For example, `harmony pr #backport #bugfix` would create a PR and apply the
-`backport` and `bugfix` labels.
+For example, `harmony pr \#backport \#bugfix` would create a PR and apply the
+`backport` and `bugfix` labels. Note that some shells will require you to escape
+the `#` or else it will be considered a comment and not passed to harmony as an
+argument.
 
 If you are using harmony from a script or some other environment without TTY
 support, harmony will print a GitHub URL that can be used to create the PR. This
@@ -193,7 +195,7 @@ harmony pr --draft
 
 Create a PR for the current branch and add the `urgent` label:
 ```shell
-harmony pr #urgent
+harmony pr \#urgent
 ```
 
 Create a pull request that will merge into the hypothetical pre-existing
@@ -229,13 +231,34 @@ title at the CLI then you will be prompted to enter the issue title
 interactively. You will also be prompted for the issue description interactively
 regardless.
 
+### Examples
+Create an issue and bugfix branch:
+```shell
+harmony quick --bugfix
+```
+
+Create an issue with the title 'widget fails to create' and bugfix branch:
+```shell
+harmony quick --bugfix widget fails to create
+```
+
+Create a branch for the existing issue with GitHub issue number `345`:
+```shell
+harmony quick \#345
+```
+
+Create an issue (and branch) and associate it with the 'Cool Features' project:
+```shell
+harmony quick --project "Cool Features"
+```
+
 ## `reflect`
 Show a summary of your review requests and authored pull requests.
 
 <!-- image location is intentionally relative to repository root -->
 ![Reflect Screenshot](./docs/images/reflect.png)
 
-## `request {team-slug | +user-login} [options]`
+## `request {<team-slug> | +<user-login>} [#<label>] [...]`
 Helps you create a PR if one does not exist yet and then it will request reviews
 from teams and/or users.
 

--- a/man/harmony.1
+++ b/man/harmony.1
@@ -8,7 +8,7 @@ Harmony \- Harmonize with coworkers around GitHub reviewing
 .PD 0
 .P
 .PD
-\f[CR]harmony config {property} [value]\f[R]
+\f[CR]harmony config [property] [value]\f[R]
 .PD 0
 .P
 .PD
@@ -255,7 +255,7 @@ Use colors suited better for either a dark or light Terminal background.
 If the \f[CR]$GITHUB_PAT\f[R] and \f[CR]$GH_TOKEN\f[R] environment
 variables are not set, this Personal Access Token is used to
 authenticate with GitHub.
-.SS \f[CR]contribute [options]\f[R]
+.SS \f[CR]contribute [\-c/\-\-checkout | \-l/\-\-list] [\-<num>] [\-i/\-\-ignore {<uri> | <pr\-number>}]\f[R]
 Print the URI of the oldest non\-draft PR waiting for your review.
 If you are not requested for review on any PRs, Harmony will suggest a
 PR that your review is not requested on.
@@ -397,8 +397,12 @@ argument if you want to as an alternative to the interactive prompt.
 .PP
 You can also specify any number of labels to apply by prefixing them
 with `#'.
-For example, \f[CR]harmony pr #backport #bugfix\f[R] would create a PR
-and apply the \f[CR]backport\f[R] and \f[CR]bugfix\f[R] labels.
+For example, \f[CR]harmony pr \(rs#backport \(rs#bugfix\f[R] would
+create a PR and apply the \f[CR]backport\f[R] and \f[CR]bugfix\f[R]
+labels.
+Note that some shells will require you to escape the \f[CR]#\f[R] or
+else it will be considered a comment and not passed to harmony as an
+argument.
 .PP
 If you are using harmony from a script or some other environment without
 TTY support, harmony will print a GitHub URL that can be used to create
@@ -422,7 +426,7 @@ harmony pr \-\-draft
 Create a PR for the current branch and add the \f[CR]urgent\f[R] label:
 .IP
 .EX
-harmony pr #urgent
+harmony pr \(rs#urgent
 .EE
 .PP
 Create a pull request that will merge into the hypothetical
@@ -464,9 +468,36 @@ If you don\(cqt specify a title at the CLI then you will be prompted to
 enter the issue title interactively.
 You will also be prompted for the issue description interactively
 regardless.
+.SS Examples
+Create an issue and bugfix branch:
+.IP
+.EX
+harmony quick \-\-bugfix
+.EE
+.PP
+Create an issue with the title `widget fails to create' and bugfix
+branch:
+.IP
+.EX
+harmony quick \-\-bugfix widget fails to create
+.EE
+.PP
+Create a branch for the existing issue with GitHub issue number
+\f[CR]345\f[R]:
+.IP
+.EX
+harmony quick \(rs#345
+.EE
+.PP
+Create an issue (and branch) and associate it with the `Cool Features'
+project:
+.IP
+.EX
+harmony quick \-\-project \(dqCool Features\(dq
+.EE
 .SS \f[CR]reflect\f[R]
 Show a summary of your review requests and authored pull requests.
-.SS \f[CR]request {team\-slug | +user\-login} [options]\f[R]
+.SS \f[CR]request {<team\-slug> | +<user\-login>} [#<label>] [...]\f[R]
 Helps you create a PR if one does not exist yet and then it will request
 reviews from teams and/or users.
 .PP

--- a/src/Commands/Help.idr
+++ b/src/Commands/Help.idr
@@ -66,7 +66,7 @@ subcommandHelp' n@"request" = subcommand n [argument True "<team-slug> | +<user-
       """
   , reflow "Optionally apply any number of labels by prefixing them with '#'."
   ]
-subcommandHelp' n@"config" = subcommand n [argument True "<property>", argument False "<value>"] $
+subcommandHelp' n@"config" = subcommand n [argument False "<property>", argument False "<value>"] $
   [ reflow """
       Get or set the value of a configuration property. Not all properties
       can be set and read via this subcommand.
@@ -83,13 +83,13 @@ subcommandHelp' n@"pr" = subcommand n [ argument False "--ready"
                                       , argument False "#<label>"
                                       , argument False "..."] $
   [ reflow "Identify an existing PR or create a new one for the current branch."
-  , reflow "Optionally apply any number of labels by prefixing them with '#'."
-  , reflow "Optionally mark a new or existing PR as a draft with the --draft flag."
-  , reflow "Optionally mark an existing PR as ready for review with the --ready flag."
-  , reflow "Optionally create and link a GitHub Issue with --issue."
-  , reflow "Optionally specify the branch to merge into with the --into option."
-  , reflow "Optionally print a pr tree with the --print-tree flag."
-  , reflow "Optionally output in markdown or shell (default) format."
+  , reflow "Apply any number of labels by prefixing them with '#'."
+  , reflow "Mark a new or existing PR as a draft with the --draft flag."
+  , reflow "Mark an existing PR as ready for review with the --ready flag."
+  , reflow "Create and link a GitHub Issue with --issue."
+  , reflow "Specify the branch to merge into with the --into option."
+  , reflow "Print a pr tree with the --print-tree flag."
+  , reflow "Output in markdown or shell (default) format."
   ]
 subcommandHelp' n@"contribute" = subcommand n [ argument False "-c/--checkout | -l/--list"
                                               , argument False "-<num>"
@@ -205,6 +205,7 @@ helpDocs = vsep
         """
     , bullet $ hsep [argument' "repo", "(Full control of private repositories)"]
     , bullet $ hsep [argument' "read:org", "(Read org and team membership, read org projects)"]
+    , bullet $ argument' "read:project"
     , bullet $ argument' "read:user"
     , bullet $ argument' "user:email"
     , bullet $ argument' "read:discussion"

--- a/test/help-command/expected
+++ b/test/help-command/expected
@@ -3,7 +3,7 @@ harmony <subcommand>
 Subcommands:
   branch 
       Print the GitHub URI for the currently checked out branch.
-  config {<property>} [<value>]
+  config [<property>] [<value>]
       Get or set the value of a configuration property. Not all properties can
       be set and read via this subcommand.
       properties: requestTeams, requestUsers, commentOnRequest, branchParsing,
@@ -39,19 +39,19 @@ Subcommands:
   pr [--ready] [--draft] [--issue] [-i/--into {<branch-name>}] [--print-tree] [-o/--output {format}] [#<label>] [...]
       Identify an existing PR or create a new one for the current branch.
 
-      Optionally apply any number of labels by prefixing them with '#'.
+      Apply any number of labels by prefixing them with '#'.
 
-      Optionally mark a new or existing PR as a draft with the --draft flag.
+      Mark a new or existing PR as a draft with the --draft flag.
 
-      Optionally mark an existing PR as ready for review with the --ready flag.
+      Mark an existing PR as ready for review with the --ready flag.
 
-      Optionally create and link a GitHub Issue with --issue.
+      Create and link a GitHub Issue with --issue.
 
-      Optionally specify the branch to merge into with the --into option.
+      Specify the branch to merge into with the --into option.
 
-      Optionally print a pr tree with the --print-tree flag.
+      Print a pr tree with the --print-tree flag.
 
-      Optionally output in markdown or shell (default) format.
+      Output in markdown or shell (default) format.
   quick [--bugfix] [--project {<project-number> | <project-title>}] [<title> | #<issue-number>] [...]
       Quickly spin up new work with a GitHub issue and associated feature
       branch. If you have harmony configured to parse GitHub issue numbers
@@ -104,6 +104,7 @@ Authentication:
   Your Personal Access Token should have the following permissions:
   - repo (Full control of private repositories)
   - read:org (Read org and team membership, read org projects)
+  - read:project
   - read:user
   - user:email
   - read:discussion


### PR DESCRIPTION
<!--

## GitHub Issue
Update help command output
--

-->
- auth token requires read:project
- config first argument now optional
- drop "Optional" word from the paragraphs of the pr help output. They are just verbosity

Closes #336
Closes #335