### PR TITLE
Support issue flag on existing PRs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,17 +168,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1782122797,
-        "narHash": "sha256-V80EW0uZR8iQSW995zfKibQ656w4YfS94pm8vn8z1F4=",
+        "lastModified": 1783610503,
+        "narHash": "sha256-TIBqpsWymgwCL3VrQJdKNhHxYAivEWycVyn1hqGDMes=",
         "owner": "idris-lang",
         "repo": "idris2",
-        "rev": "fd405085b3cf37ef7b684ccbb7e791d293ed150b",
+        "rev": "0fb7253b8cd89627d5d4456d0d0994a8d226b849",
         "type": "github"
       },
       "original": {
         "owner": "idris-lang",
         "repo": "idris2",
-        "rev": "fd405085b3cf37ef7b684ccbb7e791d293ed150b",
+        "rev": "0fb7253b8cd89627d5d4456d0d0994a8d226b849",
         "type": "github"
       }
     },
@@ -286,11 +286,11 @@
     "idris2PackDbSrc": {
       "flake": false,
       "locked": {
-        "lastModified": 1783293676,
-        "narHash": "sha256-Op4gYy2i9d471yP632Fj8aukwz4oSJu7PdMuxvgcVYM=",
+        "lastModified": 1783725245,
+        "narHash": "sha256-BUJ1Hig5txsbKwdAUH6v55wDd/BNrbqLkVn43indOfk=",
         "owner": "stefan-hoeck",
         "repo": "idris2-pack-db",
-        "rev": "1ba9bd50b2f5e5d1a58ab694c9285161d8aac563",
+        "rev": "ae0b8b9ae5efe04178444bd4f893b0089d5e1878",
         "type": "github"
       },
       "original": {
@@ -368,11 +368,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783279667,
-        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "lastModified": 1783604885,
+        "narHash": "sha256-tzMgSkV7kljEkqIjlgV6F+n+xD+/a35Db8bs7a4BFAo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "rev": "767b0d3ec98a143ad9ed7dfc0d5553510ac27133",
         "type": "github"
       },
       "original": {
@@ -384,11 +384,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783279667,
-        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "lastModified": 1783604885,
+        "narHash": "sha256-tzMgSkV7kljEkqIjlgV6F+n+xD+/a35Db8bs7a4BFAo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "rev": "767b0d3ec98a143ad9ed7dfc0d5553510ac27133",
         "type": "github"
       },
       "original": {
@@ -406,11 +406,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783315465,
-        "narHash": "sha256-3tTllS1noOl6kJKhJgSptgc4GZQPOrS5MoyuR25rDf0=",
+        "lastModified": 1783796730,
+        "narHash": "sha256-vUhX+3ZrABbzyoAoIo5FpOlrJ6S9cMseglg0oeg+qbM=",
         "owner": "mattpolzin",
         "repo": "nix-idris2-packages",
-        "rev": "bdb856f36713e79d4007239fbfe23039510bb77c",
+        "rev": "00c8f580bda5befb9b1aa61a2ed57fee34a93c71",
         "type": "github"
       },
       "original": {

--- a/src/Commands.idr
+++ b/src/Commands.idr
@@ -101,7 +101,7 @@ label @{config} labels =
 
 prUsageError  : String
 prUsageError = 
-  "pr's arguments must be #<label>, --into <branch-name>, --print-tree, --output <format>, --ready, --draft, or --issue."
+  "pr's arguments must be #<label>, --into <branch-name>, --print-tree, --output <format>, --ready, --draft, --issue, or --project <project-ref>."
 
 data IntoOpt = Branch (Exists String.NonEmpty)
 

--- a/src/Commands/PullRequest.idr
+++ b/src/Commands/PullRequest.idr
@@ -293,10 +293,10 @@ record BranchInferredData where
 noInferredData : BranchInferredData
 noInferredData = MkInferredData Nothing Nothing Nothing Nothing
 
-relatedToBranchStr : (closes : Bool) -> (bugfix : Bool) -> (issueNumber : String) -> String
-relatedToBranchStr False _     issueNumber = "Related to #\{issueNumber}"
-relatedToBranchStr True  False issueNumber = "Closes #\{issueNumber}"
-relatedToBranchStr True  True  issueNumber = "Fixes #\{issueNumber}"
+relatedToIssueStr : (closes : Bool) -> (bugfix : Bool) -> (issueNumber : String) -> String
+relatedToIssueStr False _     issueNumber = "Related to #\{issueNumber}"
+relatedToIssueStr True  False issueNumber = "Closes #\{issueNumber}"
+relatedToIssueStr True  True  issueNumber = "Fixes #\{issueNumber}"
 
 titlePrefixForBranch : Config => (bugfix : Bool) -> String
 titlePrefixForBranch @{config} False = ""
@@ -328,7 +328,7 @@ issueBodyPrefix closesWithPR bugfix maybeTree issue =
   """
   \{issueDescriptionPrefix maybeTree issue}
 
-  \{relatedToBranchStr closesWithPR bugfix (show issue.number)}
+  \{relatedToIssueStr closesWithPR bugfix (show issue.number)}
   """
 
 ||| Get the chain of PRs that lead from the given branch to the configured
@@ -570,6 +570,10 @@ record IssueTemplate where
 ||| through creating a new PR in-terminal. Otherwise, a GitHub URL is returned
 ||| that, when visited, will allow the user to create a PR for the current
 ||| branch in-browser.
+|||
+||| If an issue template is provided (by default this arg is `Nothing`) that
+||| indicates that a new issue should be created and associated with the
+||| identified or created PR.
 export
 identifyOrCreatePR : Config => Octokit => 
                      {default False markAsDraft : Bool}
@@ -579,18 +583,11 @@ identifyOrCreatePR : Config => Octokit =>
                   -> Promise' CreatePRResult
 identifyOrCreatePR @{config} {markAsDraft} {issueTemplate} {intoBranch} branch = do
   [openPr] <- listPRsForBranch config.org config.repo branch
-    | [] => do
-        when (isJust issueTemplate && isJust (parseGithubIssueNumber branch)) $
-          reject "The current branch already appears to reference a GitHub issue; --issue would create a duplicate issue."
-        if config.ttyStdout
-             then Actual Created <$> createPR
-             else if isJust issueTemplate
-                     then reject "The --issue option requires an interactive terminal because Harmony needs to prompt for issue details."
-                     else pure (Hypothetical $ prCreationUrl config.org config.repo branch intoBranch)
+    | [] => createIssueAndPR issueTemplate (parseGithubIssueNumber branch) config.ttyStdout
     | _  => reject "Multiple PRs for the current brach. Harmony only handles 1 PR per branch currently."
-  whenJust issueTemplate $ \_ =>
-    reject "The --issue option is only supported when creating a new PR."
+  maybeCreateIssueForExistingPR openPr issueTemplate
   pure (Actual Identified openPr)
+
     where
       continueGivenUncommittedChanges : Promise' Bool
       continueGivenUncommittedChanges = do
@@ -644,6 +641,26 @@ identifyOrCreatePR @{config} {markAsDraft} {issueTemplate} {intoBranch} branch =
               (notEmptyString <$> getLineEnterForDefault "What would you like the PR title to be?"
                                                          defaultTitle)
 
+      createIssue : (baseBranch : String) -> IssueTemplate -> Promise' ConfiguredIssue
+      createIssue baseBranch issueTemplate = do
+        issueForPr : Issue <-
+          createNewIssueWithMessage "Creating a new GitHub issue for this PR." baseBranch Nothing issueTemplate.project
+        pure $ configuredIssue issueForPr
+
+      maybeCreateIssueForExistingPR : PullRequest -> Maybe IssueTemplate -> Promise' ()
+      maybeCreateIssueForExistingPR _ Nothing = pure ()
+      maybeCreateIssueForExistingPR openPr (Just issueTemplate) = do
+        True <- yesNoPrompt "Do you want to create a new issue and relate it to the existing PR for this branch?"
+          | False => putStrLn "No worries, leaving the existing PR alone."
+        configuredIssue <- createIssue openPr.baseRef issueTemplate 
+        let commentPrefix = relatedToIssueStr False False (show configuredIssue.number)
+        comment <- case config.editor of
+                        Nothing => inlineDescription "What would you like the PR comment to say (two blank lines to finish)?" commentPrefix
+                        Just ed => either (const "") id <$> do
+                                     waitForEnter "write a comment relating the new issue to the current PR"
+                                     editorDescription ed Nothing commentPrefix
+        createComment config.org config.repo openPr.number comment
+
       createPR : Promise' PullRequest
       createPR = do
         -- create a remote tracking branch if needed
@@ -673,17 +690,14 @@ identifyOrCreatePR @{config} {markAsDraft} {issueTemplate} {intoBranch} branch =
 
         baseBranch <- getBaseBranch intoBranch inferredBranchInfo.baseBranchGuess
 
-        issueForPr : Maybe Issue <-
-          sequence $ issueTemplate <&> 
-                       createNewIssueWithMessage "Creating a new GitHub issue for this PR." baseBranch Nothing . project
-        let configuredIssue = configuredIssue <$> issueForPr
+        configuredIssue <- traverse (createIssue baseBranch) issueTemplate
 
         let titlePrefix = fromMaybe "" inferredBranchInfo.titlePrefix
         bodyPrefix <- case configuredIssue of
                            Just issue => buildIssueBodyPrefix branch' issue baseBranch
                            Nothing => maybe (pure "") ($ baseBranch) inferredBranchInfo.buildBodyPrefix
 
-        let defaultTitle = case issueForPr of
+        let defaultTitle = case configuredIssue of
                                 Just issue => Just issue.title
                                 Nothing => inferredBranchInfo.defaultTitle
 
@@ -701,3 +715,13 @@ identifyOrCreatePR @{config} {markAsDraft} {issueTemplate} {intoBranch} branch =
         putStrLn branch
 
         GitHub.createPR {markAsDraft} config.org config.repo branch baseBranch title description
+
+      createIssueAndPR : Maybe IssueTemplate -> (issueNumber : Maybe String) -> (isTTY : Bool) -> Promise' CreatePRResult
+      createIssueAndPR (Just _) (Just _) _ =
+        reject "The current branch already appears to reference a GitHub issue; --issue would create a duplicate issue."
+      createIssueAndPR (Just _) _ False =
+        reject "The --issue option requires an interactive terminal because Harmony needs to prompt for issue details."
+      createIssueAndPR issueTemplate issueNumber True =
+        Actual Created <$> createPR
+      createIssueAndPR Nothing _ False =
+        pure (Hypothetical $ prCreationUrl config.org config.repo branch intoBranch)

--- a/src/Commands/PullRequest.idr
+++ b/src/Commands/PullRequest.idr
@@ -650,7 +650,7 @@ identifyOrCreatePR @{config} {markAsDraft} {issueTemplate} {intoBranch} branch =
       maybeCreateIssueForExistingPR : PullRequest -> Maybe IssueTemplate -> Promise' ()
       maybeCreateIssueForExistingPR _ Nothing = pure ()
       maybeCreateIssueForExistingPR openPr (Just issueTemplate) = do
-        True <- yesNoPrompt "Do you want to create a new issue and relate it to the existing PR for this branch?"
+        True <- yesNoPrompt "Do you want to create a new issue and mention it from the existing PR for this branch?"
           | False => putStrLn "No worries, leaving the existing PR alone."
         configuredIssue <- createIssue openPr.baseRef issueTemplate 
         let commentPrefix = relatedToIssueStr False False (show configuredIssue.number)

--- a/src/Commands/PullRequest/Test.idr
+++ b/src/Commands/PullRequest/Test.idr
@@ -27,15 +27,15 @@ namespace RemoveCommentTags
   withTags = MkTTest
 
 namespace IssueBodyPrefix
-  relatedToBranchStrTest : (bugfix : Bool)
-                        -> relatedToBranchStr False bugfix "123" === "Related to #123"
-  relatedToBranchStrTest _ = Refl
+  relatedToIssueStrTest : (bugfix : Bool)
+                        -> relatedToIssueStr False bugfix "123" === "Related to #123"
+  relatedToIssueStrTest _ = Refl
 
-  relatedToBranchStrTest2 : relatedToBranchStr True True "123" === "Fixes #123"
-  relatedToBranchStrTest2 = Refl
+  relatedToIssueStrTest2 : relatedToIssueStr True True "123" === "Fixes #123"
+  relatedToIssueStrTest2 = Refl
 
-  relatedToBranchStrTest3 : relatedToBranchStr True False "123" === "Closes #123"
-  relatedToBranchStrTest3 = Refl
+  relatedToIssueStrTest3 : relatedToIssueStr True False "123" === "Closes #123"
+  relatedToIssueStrTest3 = Refl
 
 namespace RenderPrTree
   config : Config

--- a/src/Data/Issue.idr
+++ b/src/Data/Issue.idr
@@ -129,6 +129,10 @@ export
 i.title = i.issue.title
 
 export
+(.number) : ConfiguredIssue -> Integer
+i.number = i.issue.number
+
+export
 configuredIssue : Issue -> ConfiguredIssue
 configuredIssue issue =
   MkConfiguredIssue issue (commentConfig issue)


### PR DESCRIPTION
<!--

## GitHub Issue
Support issue flag on existing PRs
--
The `--issue` flag is currently only supported when the `pr` command is creating a new PR. It would be nice to lift this restriction and connect existing PRs to new issues with this flag.

I have not decided if this should be a comment on the PR that relates it to the new issue or an API call that makes the GitHub issue->pr linkage in a way that the PR merging will cause the issue to be closed.

-->

Closes #368
