### PR TITLE
unslugify prefix before matching in slow shell completion

### DIFF
--- a/src/Data/CompletionStyle.idr
+++ b/src/Data/CompletionStyle.idr
@@ -37,9 +37,18 @@ describe @{Cmds} description name = name
 describe @{CmdsAndDescriptions} description name = (name, description)
 
 public export
+escapeColons : String -> String
+escapeColons = pack . go . unpack
+  where
+    go : List Char -> List Char
+    go [] = []
+    go (':' :: xs) = '\\' :: ':' :: go xs
+    go (x :: xs) = x :: go xs
+
+public export
 stringify : (s : CompletionStyle) => CompletionResult @{s} -> String
 stringify @{Cmds} name = name
-stringify @{CmdsAndDescriptions} (name, desc) = "\{name}:\{desc}"
+stringify @{CmdsAndDescriptions} (name, desc) = "\{escapeColons name}:\{desc}"
 
 export
 encodeForShell : (s : CompletionStyle) -> List String -> String

--- a/src/Data/CompletionStyle/Test.idr
+++ b/src/Data/CompletionStyle/Test.idr
@@ -1,0 +1,14 @@
+module Data.CompletionStyle.Test
+
+import Data.CompletionStyle
+
+namespace EscapeColons
+  emptyString : escapeColons "" === ""
+  emptyString = Refl
+
+  noColons : escapeColons "hello world" === "hello world"
+  noColons = Refl
+
+  colon : escapeColons "Hello: A World Story" === "Hello\\: A World Story"
+  colon = Refl
+

--- a/src/ShellCompletion/Common.idr
+++ b/src/ShellCompletion/Common.idr
@@ -427,7 +427,7 @@ issueByNum partialArg i = (, i) <$> hashifyIfPrefix partialArg i.number
 
 issueByTitle : (partialArg : String) -> Issue -> Maybe (String, Issue)
 issueByTitle partialArg i =
-  if partialArg `isStrPrefixOf` i.title
+  if (unslugify partialArg) `isStrPrefixOf` i.title
      then Just (slugify i.title, i)
      else Nothing
 

--- a/src/ShellCompletion/Common/Test.idr
+++ b/src/ShellCompletion/Common/Test.idr
@@ -78,4 +78,9 @@ namespace IssuesByNumAndTitle
   allIssuesForUnslugifiedTitleMatch : 
     map Builtin.fst (issuesByNumAndTitle "Issue 1" IssuesByNumAndTitle.testIssues)
       ==> ["Issue◌1"]
-  allIssuesForUnslugifiedTitleMatch  = MkTTest
+  allIssuesForUnslugifiedTitleMatch = MkTTest
+
+  sluggyPrefixMatchesTitle :
+    map Builtin.fst (issuesByNumAndTitle "Issue◌" IssuesByNumAndTitle.testIssues)
+      ==> ["Issue◌1"]
+  sluggyPrefixMatchesTitle = MkTTest


### PR DESCRIPTION
<!--

## GitHub Issue
unslugify prefix before matching in slow shell completion
--
The slow command's shell completion fails to prefix-match its own suggestions to issue titles because shell completions are slugified. unslugify the prefix before checking for match against an issue title.

-->

Closes #416
Fixes #413
