### PR TITLE
Better output spacing for slow inline title prompts

### DIFF
--- a/src/Commands/Slow.idr
+++ b/src/Commands/Slow.idr
@@ -97,7 +97,10 @@ slowStartWork @{config} issue {stubIssueOut} = do
 
     inlineDescriptionPrompt : String
     inlineDescriptionPrompt =
-        "Enter one issue title per line (two blank lines to finish)"
+        """
+
+        Enter one issue title per line (two blank lines to finish)
+        """
 
     instructions : String
     instructions = """


### PR DESCRIPTION
<!--

## GitHub Issue
Better output spacing for slow inline title prompts
--
 close-with-pr: yes

Just adding a newline above a call-to-action prompt to make the output easier to read

-->

Closes #419
